### PR TITLE
조커 2장 덱 선택 시 정보 표시 버그 수정

### DIFF
--- a/client/src/components/GameHistoryDetail.tsx
+++ b/client/src/components/GameHistoryDetail.tsx
@@ -204,12 +204,13 @@ const GameHistoryDetail: React.FC<GameHistoryDetailProps> = ({
   onClose,
   history,
 }) => {
-  if (!isOpen || !history) return null;
-
-  // 닉네임 맵 캐싱 (성능 최적화)
+  // 닉네임 맵 캐싱 (성능 최적화) - Hook은 항상 최상위에서 호출
   const playerNicknameMap = React.useMemo(() => {
+    if (!history) return new Map();
     return new Map(history.players.map((p) => [p.playerId, p.nickname]));
   }, [history]);
+
+  if (!isOpen || !history) return null;
 
   // 라운드별로 플레이 기록 그룹화
   const groupedPlays: Record<number, RoundPlay[]> = {};

--- a/client/src/pages/SelectCardDeck.tsx
+++ b/client/src/pages/SelectCardDeck.tsx
@@ -214,7 +214,11 @@ const SelectCardDeck: React.FC = () => {
 
   const currentTurnPlayer = game?.players.find((p) => p.id === game.currentTurn);
   const allPlayersSelected = game?.players.every((player) => player.cards.length > 0);
-  const rankChanged = sortedPlayers[0]?.id !== game?.currentTurn && allPlayersSelected;
+
+  // 조커 2장을 가진 플레이어 찾기
+  const doubleJokerPlayer = allPlayersSelected
+    ? game?.players.find(p => p.cards.filter(card => card.isJoker).length === 2)
+    : null;
 
   useEffect(() => {
     let timer: NodeJS.Timeout;
@@ -300,9 +304,9 @@ const SelectCardDeck: React.FC = () => {
           <JokerText>
             <strong>✨ 모든 플레이어가 카드를 선택했습니다!</strong>
           </JokerText>
-          {rankChanged ? (
+          {doubleJokerPlayer ? (
             <JokerText>
-              🃏 <strong>{currentTurnPlayer?.nickname}님</strong>이 조커 2장을
+              🃏 <strong>{doubleJokerPlayer.nickname}님</strong>이 조커 2장을
               받아 1등이 되었습니다!
             </JokerText>
           ) : (


### PR DESCRIPTION
## 문제

조커가 2장 들어있는 덱을 선택한 플레이어가 있어도 플레이 화면으로 넘어가기 전까지는 해당 정보가 표시되지 않는 버그가 있었습니다.

## 원인 분석

`SelectCardDeck.tsx`에서 rank 변경 여부를 잘못 계산하고 있었습니다:

```tsx
const rankChanged = sortedPlayers[0]?.id !== game?.currentTurn && allPlayersSelected;
```

**문제점**:
1. 서버에서 조커 2장을 받은 플레이어의 rank를 1로 변경
2. 동시에 `currentTurn`도 해당 플레이어로 변경
3. 결과적으로 `sortedPlayers[0]` (1등)과 `game.currentTurn`이 같은 플레이어가 됨
4. `rankChanged`가 항상 `false`가 되어 "조커 2장을 받은 플레이어가 없습니다"라는 잘못된 메시지 표시

## 해결 방법

각 플레이어의 카드를 직접 확인하여 조커 2장을 가진 플레이어를 감지하도록 변경했습니다:

```tsx
// 조커 2장을 가진 플레이어 찾기
const doubleJokerPlayer = allPlayersSelected
  ? game?.players.find(p => p.cards.filter(card => card.isJoker).length === 2)
  : null;

// UI에서 사용
{doubleJokerPlayer ? (
  <JokerText>
    🃏 <strong>{doubleJokerPlayer.nickname}님</strong>이 조커 2장을 받아 1등이 되었습니다!
  </JokerText>
) : (
  <JokerText>
    조커 2장을 받은 플레이어가 없습니다. 순위가 그대로 유지됩니다.
  </JokerText>
)}
```

## 변경 사항

### `client/src/pages/SelectCardDeck.tsx`
- ❌ 잘못된 `rankChanged` 계산 로직 제거
- ✅ `doubleJokerPlayer` 변수 추가: 실제 카드 데이터 기반으로 조커 2장 플레이어 감지
- ✅ UI 메시지를 `doubleJokerPlayer` 존재 여부로 판단하도록 수정

### `client/src/components/GameHistoryDetail.tsx`
- ✅ React Hook 규칙 위반 수정: `useMemo`를 early return 이전으로 이동

## 테스트

- ✅ 클라이언트 빌드 성공
- ✅ ESLint 검사 통과
- ✅ React Hook 규칙 준수

## 영향

이제 모든 플레이어가 덱을 선택하면 즉시 조커 2장을 받은 플레이어 정보가 올바르게 표시됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)