### PR TITLE
Phase 5-1: 테스트 작성 및 누락 기능 구현

### DIFF
--- a/server/__tests__/e2e/FullGameFlow.test.ts
+++ b/server/__tests__/e2e/FullGameFlow.test.ts
@@ -151,9 +151,6 @@ describe('Full Game Flow E2E Tests', () => {
       expect(game!.selectableDecks).toBeDefined();
       expect(game!.selectableDecks?.length).toBe(4); // 4명이므로 4개 덱
 
-      // 역할에 따라 정렬된 플레이어 목록 (테스트 검증용)
-      const sortedPlayers = game!.players.slice().sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
-
       // ==================== Phase 3: 덱 선택 (Deck Selection) ====================
 
       // 3-1. 각 플레이어가 순서대로 덱 선택 (rank 순서: 1, 2, 3, 4)

--- a/server/__tests__/e2e/FullGameFlow.test.ts
+++ b/server/__tests__/e2e/FullGameFlow.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Full Game Flow E2E Tests
+ *
+ * 대기실 → 역할 선택 → 덱 선택 → 혁명/세금 → 게임 플레이 전체 플로우 테스트
+ */
+
+import { GameCommandService } from '../../src/application/services/GameCommandService';
+import { MongoGameRepository } from '../../src/infrastructure/repositories/MongoGameRepository';
+import { CreateGameUseCase } from '../../src/application/use-cases/game/CreateGameUseCase';
+import { JoinGameUseCase } from '../../src/application/use-cases/game/JoinGameUseCase';
+import { LeaveGameUseCase } from '../../src/application/use-cases/game/LeaveGameUseCase';
+import { ReadyGameUseCase } from '../../src/application/use-cases/game/ReadyGameUseCase';
+import { StartGameUseCase } from '../../src/application/use-cases/game/StartGameUseCase';
+import { SelectRoleUseCase } from '../../src/application/use-cases/game/SelectRoleUseCase';
+import { SelectDeckUseCase } from '../../src/application/use-cases/game/SelectDeckUseCase';
+import { SelectRevolutionUseCase } from '../../src/application/use-cases/game/SelectRevolutionUseCase';
+import { PlayCardUseCase } from '../../src/application/use-cases/game/PlayCardUseCase';
+import { PassTurnUseCase } from '../../src/application/use-cases/game/PassTurnUseCase';
+import { VoteNextGameUseCase } from '../../src/application/use-cases/game/VoteNextGameUseCase';
+import { DeleteGameUseCase } from '../../src/application/use-cases/game/DeleteGameUseCase';
+import { RoomId } from '../../src/domain/value-objects/RoomId';
+
+// 환경 변수 또는 기본값 사용
+const MONGO_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017';
+const DB_NAME = 'dalmuti-test-e2e';
+
+describe('Full Game Flow E2E Tests', () => {
+  let service: GameCommandService;
+  let repository: MongoGameRepository;
+  let startGameUseCase: StartGameUseCase;
+  let selectRoleUseCase: SelectRoleUseCase;
+  let selectDeckUseCase: SelectDeckUseCase;
+  let selectRevolutionUseCase: SelectRevolutionUseCase;
+  let playCardUseCase: PlayCardUseCase;
+  let passTurnUseCase: PassTurnUseCase;
+
+  beforeAll(async () => {
+    // 실제 MongoDB 연결
+    repository = new MongoGameRepository(MONGO_URI, DB_NAME);
+    await repository.connect();
+
+    // Use Cases 생성
+    const createGameUseCase = new CreateGameUseCase(repository);
+    const joinGameUseCase = new JoinGameUseCase(repository);
+    const leaveGameUseCase = new LeaveGameUseCase(repository);
+    const readyGameUseCase = new ReadyGameUseCase(repository);
+    startGameUseCase = new StartGameUseCase(repository);
+    selectRoleUseCase = new SelectRoleUseCase(repository);
+    selectDeckUseCase = new SelectDeckUseCase(repository);
+    selectRevolutionUseCase = new SelectRevolutionUseCase(repository);
+    playCardUseCase = new PlayCardUseCase(repository);
+    passTurnUseCase = new PassTurnUseCase(repository);
+    const voteNextGameUseCase = new VoteNextGameUseCase(repository);
+    const deleteGameUseCase = new DeleteGameUseCase(repository);
+
+    // Application Service 생성
+    service = new GameCommandService(
+      createGameUseCase,
+      joinGameUseCase,
+      leaveGameUseCase,
+      readyGameUseCase,
+      startGameUseCase,
+      selectRoleUseCase,
+      selectDeckUseCase,
+      selectRevolutionUseCase,
+      playCardUseCase,
+      passTurnUseCase,
+      voteNextGameUseCase,
+      deleteGameUseCase
+    );
+  });
+
+  afterAll(async () => {
+    // MongoDB 연결 해제
+    await repository.disconnect();
+  });
+
+  beforeEach(async () => {
+    // 각 테스트 전에 컬렉션 정리
+    const collection = repository.getCollection();
+    await collection.deleteMany({});
+  });
+
+  afterEach(async () => {
+    // 각 테스트 후에도 컬렉션 정리 (테스트 격리 보장)
+    const collection = repository.getCollection();
+    await collection.deleteMany({});
+  });
+
+  describe('Complete Game Flow: Waiting Room → Role Selection → Deck Selection → Tax/Revolution → Playing', () => {
+    it('should complete full game flow from waiting room to playing phase', async () => {
+      // ==================== Phase 1: 대기실 (Waiting Room) ====================
+
+      // 1-1. 게임 생성 및 생성자 참가
+      const createResult = await service.createAndJoinGame('player1', 'Alice');
+      expect(createResult.success).toBe(true);
+      const roomId = createResult.success ? createResult.data.roomId : '';
+
+      // 1-2. 3명 추가 참가 (총 4명)
+      const joinUseCase = new JoinGameUseCase(repository);
+      const join2 = await joinUseCase.execute({
+        roomId,
+        playerId: 'player2',
+        nickname: 'Bob',
+      });
+      const join3 = await joinUseCase.execute({
+        roomId,
+        playerId: 'player3',
+        nickname: 'Charlie',
+      });
+      const join4 = await joinUseCase.execute({
+        roomId,
+        playerId: 'player4',
+        nickname: 'David',
+      });
+
+      expect(join2.success).toBe(true);
+      expect(join3.success).toBe(true);
+      expect(join4.success).toBe(true);
+
+      // 1-3. 모든 플레이어 준비
+      await service.toggleReadyAndCheckStart(roomId, 'player1');
+      await service.toggleReadyAndCheckStart(roomId, 'player2');
+      await service.toggleReadyAndCheckStart(roomId, 'player3');
+      const ready4 = await service.toggleReadyAndCheckStart(roomId, 'player4');
+
+      expect(ready4.success).toBe(true);
+      if (ready4.success) {
+        expect(ready4.data.canStartGame).toBe(true);
+      }
+
+      // 1-4. 게임 시작
+      const startResult = await startGameUseCase.execute({ roomId });
+      expect(startResult.success).toBe(true);
+      if (startResult.success) {
+        expect(startResult.data.phase).toBe('roleSelection');
+      }
+
+      // 1-5. DB에서 게임 상태 확인
+      let game = await repository.findById(RoomId.from(roomId));
+      expect(game).not.toBeNull();
+      expect(game!.phase).toBe('roleSelection');
+      expect(game!.deck).toBeDefined();
+      expect(game!.deck?.length).toBe(54); // 52 + 2 jokers
+      expect(game!.roleSelectionCards).toBeDefined();
+      expect(game!.roleSelectionCards?.length).toBe(13);
+
+      // ==================== Phase 2: 역할 선택 (Role Selection) ====================
+
+      // 2-1. 각 플레이어가 역할 카드 선택 (1-4번 카드 선택)
+      const role1 = await selectRoleUseCase.execute({
+        roomId,
+        playerId: 'player1',
+        roleNumber: 1,
+      });
+      const role2 = await selectRoleUseCase.execute({
+        roomId,
+        playerId: 'player2',
+        roleNumber: 2,
+      });
+      const role3 = await selectRoleUseCase.execute({
+        roomId,
+        playerId: 'player3',
+        roleNumber: 3,
+      });
+      const role4 = await selectRoleUseCase.execute({
+        roomId,
+        playerId: 'player4',
+        roleNumber: 4,
+      });
+
+      expect(role1.success).toBe(true);
+      expect(role2.success).toBe(true);
+      expect(role3.success).toBe(true);
+      expect(role4.success).toBe(true);
+
+      // 2-2. 역할 선택 완료 후 rank 할당 및 덱 생성
+      game = await repository.findById(RoomId.from(roomId));
+      expect(game).not.toBeNull();
+
+      // 역할에 따라 rank 할당 (role이 작을수록 rank도 작음 = 높은 순위)
+      const sortedPlayers = game!.players.slice().sort((a, b) => (a.role ?? 0) - (b.role ?? 0));
+      sortedPlayers.forEach((player, index) => {
+        player.assignRank(index + 1);
+      });
+
+      // 덱 분할 및 선택 가능한 덱 생성
+      const DeckService = require('../../src/domain/services/DeckService');
+      const selectableDecks = DeckService.createSelectableDecks(game!.deck!, game!.players.length);
+      game!.setSelectableDecks(selectableDecks);
+
+      // Phase를 cardSelection으로 변경
+      game!.changePhase('cardSelection');
+
+      // 첫 번째 플레이어(rank 1)의 턴으로 설정
+      game!.setCurrentTurn(sortedPlayers[0].id);
+
+      await repository.update(RoomId.from(roomId), game!);
+
+      // 상태 확인
+      game = await repository.findById(RoomId.from(roomId));
+      expect(game).not.toBeNull();
+      expect(game!.phase).toBe('cardSelection');
+      expect(game!.selectableDecks).toBeDefined();
+      expect(game!.selectableDecks?.length).toBe(4); // 4명이므로 4개 덱
+
+      // ==================== Phase 3: 덱 선택 (Deck Selection) ====================
+
+      // 3-1. 각 플레이어가 순서대로 덱 선택 (rank 순서: 1, 2, 3, 4)
+      // Helper: 아직 선택되지 않은 첫 번째 덱의 인덱스 찾기
+      const findAvailableDeckIndex = (decks: any[]): number => {
+        return decks.findIndex((deck) => !deck.isSelected);
+      };
+
+      // Player 1 덱 선택
+      game = await repository.findById(RoomId.from(roomId));
+      const deck1Index = findAvailableDeckIndex(game!.selectableDecks!);
+      const deck1 = await selectDeckUseCase.execute({
+        roomId,
+        playerId: 'player1',
+        deckIndex: deck1Index,
+      });
+      expect(deck1.success).toBe(true);
+
+      // Player 2 턴 설정 및 덱 선택
+      game = await repository.findById(RoomId.from(roomId));
+      game!.setCurrentTurn(sortedPlayers[1].id);
+      await repository.update(RoomId.from(roomId), game!);
+
+      game = await repository.findById(RoomId.from(roomId));
+      const deck2Index = findAvailableDeckIndex(game!.selectableDecks!);
+      const deck2 = await selectDeckUseCase.execute({
+        roomId,
+        playerId: 'player2',
+        deckIndex: deck2Index,
+      });
+      expect(deck2.success).toBe(true);
+
+      // Player 3 턴 설정 및 덱 선택
+      game = await repository.findById(RoomId.from(roomId));
+      game!.setCurrentTurn(sortedPlayers[2].id);
+      await repository.update(RoomId.from(roomId), game!);
+
+      game = await repository.findById(RoomId.from(roomId));
+      const deck3Index = findAvailableDeckIndex(game!.selectableDecks!);
+      const deck3 = await selectDeckUseCase.execute({
+        roomId,
+        playerId: 'player3',
+        deckIndex: deck3Index,
+      });
+      expect(deck3.success).toBe(true);
+
+      // Player 4 턴 설정 및 덱 선택
+      game = await repository.findById(RoomId.from(roomId));
+      game!.setCurrentTurn(sortedPlayers[3].id);
+      await repository.update(RoomId.from(roomId), game!);
+
+      game = await repository.findById(RoomId.from(roomId));
+      const deck4Index = findAvailableDeckIndex(game!.selectableDecks!);
+      const deck4 = await selectDeckUseCase.execute({
+        roomId,
+        playerId: 'player4',
+        deckIndex: deck4Index,
+      });
+      expect(deck4.success).toBe(true);
+
+      // 3-2. 덱 선택 완료 후 상태 확인
+      game = await repository.findById(RoomId.from(roomId));
+      expect(game).not.toBeNull();
+
+      // Phase는 조커 2장 보유자 유무에 따라 'revolution' 또는 'tax'
+      expect(['revolution', 'tax']).toContain(game!.phase);
+
+      // 3-3. 모든 플레이어가 카드를 받았는지 확인
+      expect(game!.players.every((p) => p.cards.length > 0)).toBe(true);
+
+      // ==================== Phase 4: 혁명 처리 (Revolution) ====================
+
+      // 4-1. 조커 2장 보유자 확인
+      const doubleJokerPlayer = game!.checkDoubleJoker();
+
+      if (doubleJokerPlayer) {
+        // 조커 2장 보유자가 있으면 혁명 선택
+        expect(game!.phase).toBe('revolution');
+
+        // 혁명 거부 (세금 교환으로 진행)
+        const revolutionResult = await selectRevolutionUseCase.execute({
+          roomId,
+          playerId: doubleJokerPlayer.id.value,
+          wantRevolution: false,
+        });
+
+        expect(revolutionResult.success).toBe(true);
+        if (revolutionResult.success) {
+          expect(revolutionResult.data.phase).toBe('tax');
+        }
+      } else {
+        // 조커 2장 보유자가 없으면 자동으로 tax phase로 전환되어 있어야 함
+        expect(game!.phase).toBe('tax');
+      }
+
+      // ==================== Phase 5: 세금 교환 (Tax Exchange) ====================
+
+      // 5-1. 세금 교환 후 상태 확인
+      game = await repository.findById(RoomId.from(roomId));
+      expect(game).not.toBeNull();
+      expect(game!.phase).toBe('tax');
+
+      // taxExchanges가 설정되어 있는지 확인
+      // (조커 2장 보유자가 없거나, 혁명 거부한 경우 설정됨)
+      if (game!.taxExchanges) {
+        expect(game!.taxExchanges.length).toBeGreaterThan(0);
+        // 4명: 1위↔4위 2장, 1위↔4위 2장 = 총 2개 교환 쌍
+        expect(game!.taxExchanges.length).toBe(2);
+      }
+
+      // ==================== Phase 6: 게임 플레이 준비 완료 ====================
+
+      // 6-1. 최종 게임 상태 확인
+      expect(game!.currentTurn).toBeDefined();
+      expect(game!.round).toBe(1);
+
+      // 6-2. 모든 플레이어 상태 확인
+      expect(game!.players.length).toBe(4);
+      expect(game!.players.every((p) => p.rank !== null)).toBe(true);
+      expect(game!.players.every((p) => p.role !== null)).toBe(true);
+      expect(game!.players.every((p) => p.cards.length > 0)).toBe(true);
+
+      // 전체 플로우 성공!
+      console.log(`✅ Full game flow completed successfully! Room: ${roomId}`);
+    });
+
+    it('should handle revolution acceptance (대혁명) when double joker holder is last rank', async () => {
+      // 1. 게임 생성 및 4명 참가
+      const createResult = await service.createAndJoinGame('player1', 'Alice');
+      const roomId = createResult.success ? createResult.data.roomId : '';
+
+      const joinUseCase = new JoinGameUseCase(repository);
+      await joinUseCase.execute({ roomId, playerId: 'player2', nickname: 'Bob' });
+      await joinUseCase.execute({ roomId, playerId: 'player3', nickname: 'Charlie' });
+      await joinUseCase.execute({ roomId, playerId: 'player4', nickname: 'David' });
+
+      // 2. 모든 플레이어 준비 및 게임 시작
+      await service.toggleReadyAndCheckStart(roomId, 'player1');
+      await service.toggleReadyAndCheckStart(roomId, 'player2');
+      await service.toggleReadyAndCheckStart(roomId, 'player3');
+      await service.toggleReadyAndCheckStart(roomId, 'player4');
+      await startGameUseCase.execute({ roomId });
+
+      // 3. 역할 선택 (player4를 꼴찌로 만들기 위해 13번 선택)
+      await selectRoleUseCase.execute({ roomId, playerId: 'player1', roleNumber: 1 });
+      await selectRoleUseCase.execute({ roomId, playerId: 'player2', roleNumber: 2 });
+      await selectRoleUseCase.execute({ roomId, playerId: 'player3', roleNumber: 3 });
+      await selectRoleUseCase.execute({ roomId, playerId: 'player4', roleNumber: 13 });
+
+      // 4. DB에서 게임 가져와서 rank 할당
+      let game = await repository.findById(RoomId.from(roomId));
+      expect(game).not.toBeNull();
+
+      // 역할에 따라 rank 할당
+      const sortedPlayersForRev = game!.players
+        .slice()
+        .sort((a, b) => (a.role ?? 0) - (b.role ?? 0));
+      sortedPlayersForRev.forEach((player, index) => {
+        player.assignRank(index + 1);
+      });
+
+      await repository.update(RoomId.from(roomId), game!);
+
+      // player4가 rank 4 (꼴찌)인지 확인
+      game = await repository.findById(RoomId.from(roomId));
+      const player4 = game!.players.find((p) => p.id.value === 'player4');
+      expect(player4).toBeDefined();
+      expect(player4!.rank).toBe(4);
+
+      // 조커 2장을 player4에게 할당하기 위해 덱을 조작
+      // (실제로는 덱 선택 과정에서 랜덤하게 할당되지만, 테스트를 위해 조작)
+      const Card = require('../../src/domain/entities/Card').Card;
+      const joker1 = Card.create(13, true);
+      const joker2 = Card.create(13, true);
+      const normalCard = Card.create(5, false);
+
+      player4!.assignCards([joker1, joker2, normalCard]);
+      player4!.markHasDoubleJoker();
+
+      // 다른 플레이어들에게도 카드 할당
+      game!.players
+        .filter((p) => p.id.value !== 'player4')
+        .forEach((p, i) => {
+          p.assignCards([Card.create(i + 1), Card.create(i + 2)]);
+        });
+
+      // revolution 페이즈로 변경
+      game!.changePhase('revolution');
+      game!.setCurrentTurn(player4!.id);
+
+      await repository.update(RoomId.from(roomId), game!);
+
+      // 5. 혁명 승인 (대혁명)
+      const revolutionResult = await selectRevolutionUseCase.execute({
+        roomId,
+        playerId: 'player4',
+        wantRevolution: true,
+      });
+
+      expect(revolutionResult.success).toBe(true);
+      if (revolutionResult.success) {
+        expect(revolutionResult.data.wantRevolution).toBe(true);
+        expect(revolutionResult.data.phase).toBe('playing');
+        expect(revolutionResult.data.revolutionStatus?.isRevolution).toBe(true);
+        expect(revolutionResult.data.revolutionStatus?.isGreatRevolution).toBe(true);
+
+        // 대혁명이 성공적으로 처리되었음
+        console.log(`✅ Great revolution (대혁명) test completed! Player: player4`);
+      }
+    });
+  });
+});

--- a/server/__tests__/e2e/FullGameFlow.test.ts
+++ b/server/__tests__/e2e/FullGameFlow.test.ts
@@ -19,6 +19,9 @@ import { PassTurnUseCase } from '../../src/application/use-cases/game/PassTurnUs
 import { VoteNextGameUseCase } from '../../src/application/use-cases/game/VoteNextGameUseCase';
 import { DeleteGameUseCase } from '../../src/application/use-cases/game/DeleteGameUseCase';
 import { RoomId } from '../../src/domain/value-objects/RoomId';
+import { Card } from '../../src/domain/entities/Card';
+import { DeckService } from '../../src/domain/services/DeckService';
+import { SelectableDeck } from '../../src/domain/entities/Game';
 
 // 환경 변수 또는 기본값 사용
 const MONGO_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017';
@@ -185,7 +188,6 @@ describe('Full Game Flow E2E Tests', () => {
       });
 
       // 덱 분할 및 선택 가능한 덱 생성
-      const DeckService = require('../../src/domain/services/DeckService');
       const selectableDecks = DeckService.createSelectableDecks(game!.deck!, game!.players.length);
       game!.setSelectableDecks(selectableDecks);
 
@@ -208,9 +210,8 @@ describe('Full Game Flow E2E Tests', () => {
 
       // 3-1. 각 플레이어가 순서대로 덱 선택 (rank 순서: 1, 2, 3, 4)
       // Helper: 아직 선택되지 않은 첫 번째 덱의 인덱스 찾기
-      const findAvailableDeckIndex = (decks: any[]): number => {
-        return decks.findIndex((deck) => !deck.isSelected);
-      };
+      const findAvailableDeckIndex = (decks: SelectableDeck[]): number =>
+        decks.findIndex((deck) => !deck.isSelected);
 
       // Player 1 덱 선택
       game = await repository.findById(RoomId.from(roomId));
@@ -325,9 +326,6 @@ describe('Full Game Flow E2E Tests', () => {
       expect(game!.players.every((p) => p.rank !== null)).toBe(true);
       expect(game!.players.every((p) => p.role !== null)).toBe(true);
       expect(game!.players.every((p) => p.cards.length > 0)).toBe(true);
-
-      // 전체 플로우 성공!
-      console.log(`✅ Full game flow completed successfully! Room: ${roomId}`);
     });
 
     it('should handle revolution acceptance (대혁명) when double joker holder is last rank', async () => {
@@ -375,7 +373,6 @@ describe('Full Game Flow E2E Tests', () => {
 
       // 조커 2장을 player4에게 할당하기 위해 덱을 조작
       // (실제로는 덱 선택 과정에서 랜덤하게 할당되지만, 테스트를 위해 조작)
-      const Card = require('../../src/domain/entities/Card').Card;
       const joker1 = Card.create(13, true);
       const joker2 = Card.create(13, true);
       const normalCard = Card.create(5, false);
@@ -409,9 +406,6 @@ describe('Full Game Flow E2E Tests', () => {
         expect(revolutionResult.data.phase).toBe('playing');
         expect(revolutionResult.data.revolutionStatus?.isRevolution).toBe(true);
         expect(revolutionResult.data.revolutionStatus?.isGreatRevolution).toBe(true);
-
-        // 대혁명이 성공적으로 처리되었음
-        console.log(`✅ Great revolution (대혁명) test completed! Player: player4`);
       }
     });
   });

--- a/server/__tests__/integration/application/GameCommandService.test.ts
+++ b/server/__tests__/integration/application/GameCommandService.test.ts
@@ -11,8 +11,10 @@ import { CreateGameUseCase } from '../../../src/application/use-cases/game/Creat
 import { JoinGameUseCase } from '../../../src/application/use-cases/game/JoinGameUseCase';
 import { LeaveGameUseCase } from '../../../src/application/use-cases/game/LeaveGameUseCase';
 import { ReadyGameUseCase } from '../../../src/application/use-cases/game/ReadyGameUseCase';
+import { StartGameUseCase } from '../../../src/application/use-cases/game/StartGameUseCase';
 import { SelectRoleUseCase } from '../../../src/application/use-cases/game/SelectRoleUseCase';
 import { SelectDeckUseCase } from '../../../src/application/use-cases/game/SelectDeckUseCase';
+import { SelectRevolutionUseCase } from '../../../src/application/use-cases/game/SelectRevolutionUseCase';
 import { PlayCardUseCase } from '../../../src/application/use-cases/game/PlayCardUseCase';
 import { PassTurnUseCase } from '../../../src/application/use-cases/game/PassTurnUseCase';
 import { VoteNextGameUseCase } from '../../../src/application/use-cases/game/VoteNextGameUseCase';
@@ -38,8 +40,10 @@ describe('GameCommandService Integration Tests', () => {
     const joinGameUseCase = new JoinGameUseCase(repository);
     const leaveGameUseCase = new LeaveGameUseCase(repository);
     const readyGameUseCase = new ReadyGameUseCase(repository);
+    const startGameUseCase = new StartGameUseCase(repository);
     const selectRoleUseCase = new SelectRoleUseCase(repository);
     const selectDeckUseCase = new SelectDeckUseCase(repository);
+    const selectRevolutionUseCase = new SelectRevolutionUseCase(repository);
     const playCardUseCase = new PlayCardUseCase(repository);
     const passTurnUseCase = new PassTurnUseCase(repository);
     const voteNextGameUseCase = new VoteNextGameUseCase(repository);
@@ -51,8 +55,10 @@ describe('GameCommandService Integration Tests', () => {
       joinGameUseCase,
       leaveGameUseCase,
       readyGameUseCase,
+      startGameUseCase,
       selectRoleUseCase,
       selectDeckUseCase,
+      selectRevolutionUseCase,
       playCardUseCase,
       passTurnUseCase,
       voteNextGameUseCase,

--- a/server/__tests__/presentation/socket/adapters/CardEventAdapter.test.ts
+++ b/server/__tests__/presentation/socket/adapters/CardEventAdapter.test.ts
@@ -65,7 +65,7 @@ describe('CardEventAdapter', () => {
     beforeEach(() => {
       adapter.register(mockSocket);
       const onCalls = mockSocket.on.mock.calls as [string, Function][];
-      const playCardCall = onCalls.find(call => call[0] === 'playCard');
+      const playCardCall = onCalls.find((call) => call[0] === 'playCard');
       playCardHandler = playCardCall![1];
     });
 
@@ -92,7 +92,7 @@ describe('CardEventAdapter', () => {
         data: mockGameState,
       });
       expect(mockIo.to).toHaveBeenCalledWith('room-123');
-      expect(mockIo.emit).toHaveBeenCalledWith('GAME_STATE_UPDATED', { game: mockGameState });
+      expect(mockIo.emit).toHaveBeenCalledWith('GAME_STATE_UPDATED', mockGameState);
     });
 
     it('실패 시 에러를 반환해야 한다', async () => {
@@ -119,7 +119,7 @@ describe('CardEventAdapter', () => {
     beforeEach(() => {
       adapter.register(mockSocket);
       const onCalls = mockSocket.on.mock.calls as [string, Function][];
-      const passCall = onCalls.find(call => call[0] === 'pass');
+      const passCall = onCalls.find((call) => call[0] === 'pass');
       passHandler = passCall![1];
     });
 
@@ -165,7 +165,7 @@ describe('CardEventAdapter', () => {
     beforeEach(() => {
       adapter.register(mockSocket);
       const onCalls = mockSocket.on.mock.calls as [string, Function][];
-      const selectDeckCall = onCalls.find(call => call[0] === 'selectDeck');
+      const selectDeckCall = onCalls.find((call) => call[0] === 'selectDeck');
       selectDeckHandler = selectDeckCall![1];
     });
 

--- a/server/__tests__/presentation/socket/adapters/CardEventAdapter.test.ts
+++ b/server/__tests__/presentation/socket/adapters/CardEventAdapter.test.ts
@@ -180,7 +180,7 @@ describe('CardEventAdapter', () => {
       mockQueryService.getGameState.mockResolvedValue(mockGameState as any);
 
       const callback = jest.fn();
-      await selectDeckHandler({ roomId: 'room-123', deckIndex: 0 }, callback);
+      await selectDeckHandler({ roomId: 'room-123', cardIndex: 0 }, callback);
 
       expect(mockCommandService.selectDeck).toHaveBeenCalledWith('room-123', 'socket-123', 0);
       expect(callback).toHaveBeenCalledWith({
@@ -197,7 +197,7 @@ describe('CardEventAdapter', () => {
       } as UseCaseResponse<any>);
 
       const callback = jest.fn();
-      await selectDeckHandler({ roomId: 'room-123', deckIndex: 0 }, callback);
+      await selectDeckHandler({ roomId: 'room-123', cardIndex: 0 }, callback);
 
       expect(callback).toHaveBeenCalledWith({
         success: false,

--- a/server/__tests__/presentation/socket/adapters/GameEventAdapter.test.ts
+++ b/server/__tests__/presentation/socket/adapters/GameEventAdapter.test.ts
@@ -73,7 +73,7 @@ describe('GameEventAdapter', () => {
     beforeEach(() => {
       adapter.register(mockSocket);
       const onCalls = mockSocket.on.mock.calls as [string, Function][];
-      const createGameCall = onCalls.find(call => call[0] === 'createGame');
+      const createGameCall = onCalls.find((call) => call[0] === 'createGame');
       createGameHandler = createGameCall![1];
     });
 
@@ -97,7 +97,7 @@ describe('GameEventAdapter', () => {
         data: { roomId: 'room-123', gameState: mockGameState },
       });
       expect(mockIo.to).toHaveBeenCalledWith('room-123');
-      expect(mockIo.emit).toHaveBeenCalledWith('GAME_STATE_UPDATED', { game: mockGameState });
+      expect(mockIo.emit).toHaveBeenCalledWith('GAME_STATE_UPDATED', mockGameState);
     });
 
     it('실패 시 에러를 반환해야 한다', async () => {
@@ -123,7 +123,7 @@ describe('GameEventAdapter', () => {
     beforeEach(() => {
       adapter.register(mockSocket);
       const onCalls = mockSocket.on.mock.calls as [string, Function][];
-      const joinGameCall = onCalls.find(call => call[0] === 'joinGame');
+      const joinGameCall = onCalls.find((call) => call[0] === 'joinGame');
       joinGameHandler = joinGameCall![1];
     });
 
@@ -171,7 +171,7 @@ describe('GameEventAdapter', () => {
     beforeEach(() => {
       adapter.register(mockSocket);
       const onCalls = mockSocket.on.mock.calls as [string, Function][];
-      const leaveGameCall = onCalls.find(call => call[0] === 'leaveGame');
+      const leaveGameCall = onCalls.find((call) => call[0] === 'leaveGame');
       leaveGameHandler = leaveGameCall![1];
       playerRooms.set('socket-123', 'room-123');
     });
@@ -204,7 +204,7 @@ describe('GameEventAdapter', () => {
     beforeEach(() => {
       adapter.register(mockSocket);
       const onCalls = mockSocket.on.mock.calls as [string, Function][];
-      const readyCall = onCalls.find(call => call[0] === 'ready');
+      const readyCall = onCalls.find((call) => call[0] === 'ready');
       readyHandler = readyCall![1];
     });
 
@@ -238,7 +238,7 @@ describe('GameEventAdapter', () => {
     beforeEach(() => {
       adapter.register(mockSocket);
       const onCalls = mockSocket.on.mock.calls as [string, Function][];
-      const voteCall = onCalls.find(call => call[0] === 'vote');
+      const voteCall = onCalls.find((call) => call[0] === 'vote');
       voteHandler = voteCall![1];
     });
 
@@ -268,7 +268,7 @@ describe('GameEventAdapter', () => {
     beforeEach(() => {
       adapter.register(mockSocket);
       const onCalls = mockSocket.on.mock.calls as [string, Function][];
-      const getGameStateCall = onCalls.find(call => call[0] === 'getGameState');
+      const getGameStateCall = onCalls.find((call) => call[0] === 'getGameState');
       getGameStateHandler = getGameStateCall![1];
     });
 

--- a/server/__tests__/presentation/socket/adapters/RoleSelectionEventAdapter.test.ts
+++ b/server/__tests__/presentation/socket/adapters/RoleSelectionEventAdapter.test.ts
@@ -97,7 +97,7 @@ describe('RoleSelectionEventAdapter', () => {
         data: mockGameState,
       });
       expect(mockIo.to).toHaveBeenCalledWith('room-123');
-      expect(mockIo.emit).toHaveBeenCalledWith('GAME_STATE_UPDATED', { game: mockGameState });
+      expect(mockIo.emit).toHaveBeenCalledWith('GAME_STATE_UPDATED', mockGameState);
     });
 
     it('실패 시 에러를 반환해야 한다', async () => {

--- a/server/__tests__/unit/application/use-cases/game/SelectRevolutionUseCase.test.ts
+++ b/server/__tests__/unit/application/use-cases/game/SelectRevolutionUseCase.test.ts
@@ -1,0 +1,295 @@
+/**
+ * SelectRevolutionUseCase Unit Tests
+ *
+ * Repository를 Mock하여 Use Case 로직만 격리 테스트
+ */
+
+import { SelectRevolutionUseCase } from '../../../../../src/application/use-cases/game/SelectRevolutionUseCase';
+import { IGameRepository } from '../../../../../src/application/ports/IGameRepository';
+import { SelectRevolutionRequest } from '../../../../../src/application/dto/game/SelectRevolutionDto';
+import { Game } from '../../../../../src/domain/entities/Game';
+import { Player } from '../../../../../src/domain/entities/Player';
+import { Card } from '../../../../../src/domain/entities/Card';
+import { RoomId } from '../../../../../src/domain/value-objects/RoomId';
+import { PlayerId } from '../../../../../src/domain/value-objects/PlayerId';
+
+describe('SelectRevolutionUseCase', () => {
+  let useCase: SelectRevolutionUseCase;
+  let mockRepository: jest.Mocked<IGameRepository>;
+
+  beforeEach(() => {
+    // Repository Mock 생성
+    mockRepository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+      findAll: jest.fn(),
+    };
+
+    useCase = new SelectRevolutionUseCase(mockRepository);
+  });
+
+  // 테스트용 게임 생성 헬퍼 (조커 2장 보유자 포함)
+  const createGameWithDoubleJoker = (
+    roomId: string,
+    playerCount: number = 4
+  ): { game: Game; doubleJokerPlayer: Player } => {
+    const game = Game.create(RoomId.from(roomId));
+
+    // 플레이어 추가
+    const players: Player[] = [];
+    for (let i = 1; i <= playerCount; i++) {
+      const player = Player.create(PlayerId.create(`player${i}`), `Player${i}`);
+      player.assignRank(i);
+      game.addPlayer(player);
+      players.push(player);
+    }
+
+    // 조커 2장을 특정 플레이어에게 할당
+    const doubleJokerPlayer = players[0]; // player1이 조커 2장 보유
+    doubleJokerPlayer.assignCards([
+      Card.create(13, true), // 조커 1
+      Card.create(13, true), // 조커 2
+      Card.create(5),
+    ]);
+
+    // 다른 플레이어들에게도 카드 할당
+    for (let i = 1; i < players.length; i++) {
+      players[i].assignCards([Card.create(i), Card.create(i + 1)]);
+    }
+
+    // 조커 플래그 설정
+    doubleJokerPlayer.markHasDoubleJoker();
+
+    // revolution 페이즈로 설정
+    game.changePhase('revolution');
+    game.setCurrentTurn(doubleJokerPlayer.id);
+
+    return { game, doubleJokerPlayer };
+  };
+
+  describe('성공 케이스', () => {
+    it('혁명 승인 시: 대혁명 (꼴찌 순위면 순위 반전)', async () => {
+      // Arrange
+      const { game, doubleJokerPlayer } = createGameWithDoubleJoker('ROOM01', 4);
+      // player1을 꼴찌(rank 4)로 만들기
+      doubleJokerPlayer.assignRank(4);
+
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: SelectRevolutionRequest = {
+        roomId: 'ROOM01',
+        playerId: 'player1',
+        wantRevolution: true,
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(true);
+      if (response.success) {
+        expect(response.data.wantRevolution).toBe(true);
+        expect(response.data.phase).toBe('playing');
+        expect(response.data.revolutionStatus?.isRevolution).toBe(true);
+        expect(response.data.revolutionStatus?.isGreatRevolution).toBe(true);
+      }
+      expect(mockRepository.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('혁명 승인 시: 일반혁명 (꼴찌가 아니면 순위 유지)', async () => {
+      // Arrange
+      const { game, doubleJokerPlayer } = createGameWithDoubleJoker('ROOM01', 4);
+      // player1을 2등으로 만들기
+      doubleJokerPlayer.assignRank(2);
+
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: SelectRevolutionRequest = {
+        roomId: 'ROOM01',
+        playerId: 'player1',
+        wantRevolution: true,
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(true);
+      if (response.success) {
+        expect(response.data.wantRevolution).toBe(true);
+        expect(response.data.phase).toBe('playing');
+        expect(response.data.revolutionStatus?.isRevolution).toBe(true);
+        expect(response.data.revolutionStatus?.isGreatRevolution).toBe(false);
+      }
+      expect(mockRepository.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('혁명 거부 시: 세금 교환 수행 후 tax 페이즈로 전환', async () => {
+      // Arrange
+      const { game, doubleJokerPlayer } = createGameWithDoubleJoker('ROOM01', 4);
+
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: SelectRevolutionRequest = {
+        roomId: 'ROOM01',
+        playerId: 'player1',
+        wantRevolution: false,
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(true);
+      if (response.success) {
+        expect(response.data.wantRevolution).toBe(false);
+        expect(response.data.phase).toBe('tax');
+        expect(response.data.revolutionStatus).toBeUndefined();
+      }
+      expect(mockRepository.update).toHaveBeenCalledTimes(1);
+
+      // 세금 교환이 수행되었는지 확인 (game.taxExchanges가 설정되었는지)
+      expect(game.taxExchanges).toBeDefined();
+      expect(game.taxExchanges?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('실패 케이스', () => {
+    it('게임을 찾을 수 없으면 실패해야 함', async () => {
+      // Arrange
+      mockRepository.findById.mockResolvedValue(null);
+
+      const request: SelectRevolutionRequest = {
+        roomId: 'ROOM99', // 유효한 형식이지만 존재하지 않는 방
+        playerId: 'player1',
+        wantRevolution: true,
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(false);
+      if (!response.success) {
+        expect(response.error.code).toBe('RESOURCE_NOT_FOUND');
+      }
+      expect(mockRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('잘못된 roomId 형식이면 실패해야 함', async () => {
+      // Arrange
+      const request: SelectRevolutionRequest = {
+        roomId: '',
+        playerId: 'player1',
+        wantRevolution: true,
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(false);
+      if (!response.success) {
+        expect(response.error.code).toBe('VALIDATION_ERROR');
+      }
+      expect(mockRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it('잘못된 playerId 형식이면 실패해야 함', async () => {
+      // Arrange
+      const request: SelectRevolutionRequest = {
+        roomId: 'ROOM01',
+        playerId: '',
+        wantRevolution: true,
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(false);
+      if (!response.success) {
+        expect(response.error.code).toBe('VALIDATION_ERROR');
+      }
+      expect(mockRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it('게임 로직에서 에러 발생 시 실패 응답을 반환해야 함', async () => {
+      // Arrange
+      const { game } = createGameWithDoubleJoker('ROOM01', 4);
+      // 잘못된 phase로 변경하여 에러 유발
+      game.changePhase('waiting');
+
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: SelectRevolutionRequest = {
+        roomId: 'ROOM01',
+        playerId: 'player1',
+        wantRevolution: true,
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(false);
+      if (!response.success) {
+        // 도메인 에러가 일반 Error로 던져지면 SELECT_REVOLUTION_FAILED로 변환됨
+        expect(response.error.code).toBe('SELECT_REVOLUTION_FAILED');
+      }
+      expect(mockRepository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('엣지 케이스', () => {
+    it('5명 플레이어 게임에서 혁명 거부 시 올바른 세금 교환 발생', async () => {
+      // Arrange
+      const { game, doubleJokerPlayer } = createGameWithDoubleJoker('ROOM01', 5);
+
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: SelectRevolutionRequest = {
+        roomId: 'ROOM01',
+        playerId: 'player1',
+        wantRevolution: false,
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(true);
+      if (response.success) {
+        expect(response.data.phase).toBe('tax');
+      }
+      // 5명: 1위↔5위 2장, 2위↔4위 1장 = 총 4개의 교환
+      expect(game.taxExchanges?.length).toBe(4);
+    });
+
+    it('8명 플레이어 게임에서 혁명 거부 시 올바른 세금 교환 발생', async () => {
+      // Arrange
+      const { game, doubleJokerPlayer } = createGameWithDoubleJoker('ROOM01', 8);
+
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: SelectRevolutionRequest = {
+        roomId: 'ROOM01',
+        playerId: 'player1',
+        wantRevolution: false,
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(true);
+      if (response.success) {
+        expect(response.data.phase).toBe('tax');
+      }
+      // 8명도 1위↔8위 2장, 2위↔7위 1장 = 총 4개의 교환
+      expect(game.taxExchanges?.length).toBe(4);
+    });
+  });
+});

--- a/server/__tests__/unit/application/use-cases/game/SelectRevolutionUseCase.test.ts
+++ b/server/__tests__/unit/application/use-cases/game/SelectRevolutionUseCase.test.ts
@@ -128,7 +128,7 @@ describe('SelectRevolutionUseCase', () => {
 
     it('혁명 거부 시: 세금 교환 수행 후 tax 페이즈로 전환', async () => {
       // Arrange
-      const { game, doubleJokerPlayer } = createGameWithDoubleJoker('ROOM01', 4);
+      const { game } = createGameWithDoubleJoker('ROOM01', 4);
 
       mockRepository.findById.mockResolvedValue(game);
 
@@ -246,7 +246,7 @@ describe('SelectRevolutionUseCase', () => {
   describe('엣지 케이스', () => {
     it('5명 플레이어 게임에서 혁명 거부 시 올바른 세금 교환 발생', async () => {
       // Arrange
-      const { game, doubleJokerPlayer } = createGameWithDoubleJoker('ROOM01', 5);
+      const { game } = createGameWithDoubleJoker('ROOM01', 5);
 
       mockRepository.findById.mockResolvedValue(game);
 
@@ -270,7 +270,7 @@ describe('SelectRevolutionUseCase', () => {
 
     it('8명 플레이어 게임에서 혁명 거부 시 올바른 세금 교환 발생', async () => {
       // Arrange
-      const { game, doubleJokerPlayer } = createGameWithDoubleJoker('ROOM01', 8);
+      const { game } = createGameWithDoubleJoker('ROOM01', 8);
 
       mockRepository.findById.mockResolvedValue(game);
 

--- a/server/__tests__/unit/application/use-cases/game/SelectRoleUseCase.test.ts
+++ b/server/__tests__/unit/application/use-cases/game/SelectRoleUseCase.test.ts
@@ -10,6 +10,7 @@ import { SelectRoleRequest } from '../../../../../src/application/dto/game/Selec
 import { NotFoundError } from '../../../../../src/application/ports/RepositoryError';
 import { Game } from '../../../../../src/domain/entities/Game';
 import { Player } from '../../../../../src/domain/entities/Player';
+import { Card } from '../../../../../src/domain/entities/Card';
 import { RoomId } from '../../../../../src/domain/value-objects/RoomId';
 import { PlayerId } from '../../../../../src/domain/value-objects/PlayerId';
 
@@ -91,6 +92,18 @@ describe('SelectRoleUseCase', () => {
     it('should return allRolesSelected=true when all players selected roles', async () => {
       // Arrange
       const game = createTestGame('ROOM02', 4);
+
+      // 덱 초기화 (allRolesSelected일 때 덱이 필요함)
+      const deckCards = [];
+      for (let rank = 1; rank <= 13; rank++) {
+        for (let i = 0; i < 4; i++) {
+          deckCards.push(Card.create(rank, false));
+        }
+      }
+      // 조커 2장 추가 (rank는 13)
+      deckCards.push(Card.create(13, true));
+      deckCards.push(Card.create(13, true));
+      game.setDeck(deckCards);
 
       // 3명의 플레이어가 이미 역할을 선택한 상태
       const player1 = game.getPlayer(PlayerId.create('player1'))!;

--- a/server/__tests__/unit/application/use-cases/game/StartGameUseCase.test.ts
+++ b/server/__tests__/unit/application/use-cases/game/StartGameUseCase.test.ts
@@ -1,0 +1,297 @@
+/**
+ * StartGameUseCase Unit Tests
+ *
+ * Repository를 Mock하여 Use Case 로직만 격리 테스트
+ */
+
+import { StartGameUseCase } from '../../../../../src/application/use-cases/game/StartGameUseCase';
+import { IGameRepository } from '../../../../../src/application/ports/IGameRepository';
+import { StartGameRequest } from '../../../../../src/application/dto/game/StartGameDto';
+import { Game } from '../../../../../src/domain/entities/Game';
+import { Player } from '../../../../../src/domain/entities/Player';
+import { RoomId } from '../../../../../src/domain/value-objects/RoomId';
+import { PlayerId } from '../../../../../src/domain/value-objects/PlayerId';
+
+describe('StartGameUseCase', () => {
+  let useCase: StartGameUseCase;
+  let mockRepository: jest.Mocked<IGameRepository>;
+
+  beforeEach(() => {
+    // Repository Mock 생성
+    mockRepository = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn(),
+      findAll: jest.fn(),
+    };
+
+    useCase = new StartGameUseCase(mockRepository);
+  });
+
+  // 테스트용 게임 생성 헬퍼
+  const createTestGame = (roomId: string, playerCount: number = 4): Game => {
+    const game = Game.create(RoomId.from(roomId));
+
+    // 플레이어 추가
+    for (let i = 1; i <= playerCount; i++) {
+      const player = Player.create(PlayerId.create(`player${i}`), `Player${i}`);
+      game.addPlayer(player);
+      player.ready(); // 모든 플레이어 준비 완료
+    }
+
+    return game;
+  };
+
+  describe('성공 케이스', () => {
+    it('4명 플레이어로 게임을 시작해야 함', async () => {
+      // Arrange
+      const game = createTestGame('ROOM01', 4);
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: StartGameRequest = {
+        roomId: 'ROOM01',
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(true);
+      if (response.success) {
+        expect(response.data.roomId).toBe('ROOM01');
+        expect(response.data.phase).toBe('roleSelection');
+        expect(response.data.playerCount).toBe(4);
+      }
+
+      // Repository update 호출 확인
+      expect(mockRepository.update).toHaveBeenCalledTimes(1);
+
+      // 게임 상태 확인
+      expect(game.phase).toBe('roleSelection');
+      expect(game.deck).toBeDefined();
+      expect(game.deck?.length).toBe(54); // 표준 덱: 52장 + 조커 2장
+      expect(game.roleSelectionCards).toBeDefined();
+      expect(game.roleSelectionCards?.length).toBe(13); // 1-13 역할 카드
+    });
+
+    it('8명 플레이어로 게임을 시작해야 함', async () => {
+      // Arrange
+      const game = createTestGame('ROOM02', 8);
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: StartGameRequest = {
+        roomId: 'ROOM02',
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(true);
+      if (response.success) {
+        expect(response.data.roomId).toBe('ROOM02');
+        expect(response.data.phase).toBe('roleSelection');
+        expect(response.data.playerCount).toBe(8);
+      }
+
+      expect(mockRepository.update).toHaveBeenCalledTimes(1);
+      expect(game.phase).toBe('roleSelection');
+    });
+
+    it('덱이 올바르게 초기화되어야 함', async () => {
+      // Arrange
+      const game = createTestGame('ROOM03', 5);
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: StartGameRequest = {
+        roomId: 'ROOM03',
+      };
+
+      // Act
+      await useCase.execute(request);
+
+      // Assert
+      // 덱이 설정되었는지 확인
+      expect(game.deck).toBeDefined();
+      expect(game.deck?.length).toBe(54);
+
+      // 조커 2장 확인
+      const jokers = game.deck?.filter((card) => card.isJoker);
+      expect(jokers?.length).toBe(2);
+
+      // rank 1-13 카드 각 4장씩 확인
+      for (let rank = 1; rank <= 13; rank++) {
+        const cardsOfRank = game.deck?.filter((card) => card.rank === rank && !card.isJoker);
+        expect(cardsOfRank?.length).toBe(4);
+      }
+    });
+
+    it('역할 선택 카드가 올바르게 초기화되어야 함', async () => {
+      // Arrange
+      const game = createTestGame('ROOM04', 6);
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: StartGameRequest = {
+        roomId: 'ROOM04',
+      };
+
+      // Act
+      await useCase.execute(request);
+
+      // Assert
+      expect(game.roleSelectionCards).toBeDefined();
+      expect(game.roleSelectionCards?.length).toBe(13);
+
+      // 1-13 숫자 카드 확인
+      for (let i = 1; i <= 13; i++) {
+        const card = game.roleSelectionCards?.find((c) => c.number === i);
+        expect(card).toBeDefined();
+        expect(card?.isSelected).toBe(false);
+        expect(card?.selectedBy).toBeUndefined();
+      }
+    });
+  });
+
+  describe('실패 케이스', () => {
+    it('게임을 찾을 수 없으면 실패해야 함', async () => {
+      // Arrange
+      mockRepository.findById.mockResolvedValue(null);
+
+      const request: StartGameRequest = {
+        roomId: 'ROOM99',
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(false);
+      if (!response.success) {
+        expect(response.error.code).toBe('RESOURCE_NOT_FOUND');
+      }
+      expect(mockRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('잘못된 roomId 형식이면 실패해야 함', async () => {
+      // Arrange
+      const request: StartGameRequest = {
+        roomId: '',
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(false);
+      if (!response.success) {
+        expect(response.error.code).toBe('VALIDATION_ERROR');
+      }
+      expect(mockRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it('플레이어 수가 부족하면 실패해야 함 (3명)', async () => {
+      // Arrange
+      const game = createTestGame('ROOM05', 3);
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: StartGameRequest = {
+        roomId: 'ROOM05',
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(false);
+      if (!response.success) {
+        expect(response.error.code).toBe('BUSINESS_RULE_VIOLATION');
+        expect(response.error.message).toContain('4~8명의 플레이어가 필요합니다');
+      }
+      expect(mockRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('플레이어 수가 너무 많으면 실패해야 함 (9명)', async () => {
+      // Arrange
+      const game = createTestGame('ROOM06', 9);
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: StartGameRequest = {
+        roomId: 'ROOM06',
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(false);
+      if (!response.success) {
+        expect(response.error.code).toBe('BUSINESS_RULE_VIOLATION');
+        expect(response.error.message).toContain('4~8명의 플레이어가 필요합니다');
+      }
+      expect(mockRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('이미 시작된 게임은 다시 시작할 수 없어야 함', async () => {
+      // Arrange
+      const game = createTestGame('ROOM07', 4);
+      game.changePhase('roleSelection'); // 이미 시작된 상태
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: StartGameRequest = {
+        roomId: 'ROOM07',
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(false);
+      if (!response.success) {
+        expect(response.error.code).toBe('BUSINESS_RULE_VIOLATION');
+        expect(response.error.message).toContain('대기 중인 게임만 시작할 수 있습니다');
+      }
+      expect(mockRepository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('엣지 케이스', () => {
+    it('정확히 4명(최소)일 때 게임을 시작해야 함', async () => {
+      // Arrange
+      const game = createTestGame('ROOM08', 4);
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: StartGameRequest = {
+        roomId: 'ROOM08',
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(true);
+      if (response.success) {
+        expect(response.data.playerCount).toBe(4);
+      }
+    });
+
+    it('정확히 8명(최대)일 때 게임을 시작해야 함', async () => {
+      // Arrange
+      const game = createTestGame('ROOM09', 8);
+      mockRepository.findById.mockResolvedValue(game);
+
+      const request: StartGameRequest = {
+        roomId: 'ROOM09',
+      };
+
+      // Act
+      const response = await useCase.execute(request);
+
+      // Assert
+      expect(response.success).toBe(true);
+      if (response.success) {
+        expect(response.data.playerCount).toBe(8);
+      }
+    });
+  });
+});

--- a/server/__tests__/unit/domain/services/DeckService.test.ts
+++ b/server/__tests__/unit/domain/services/DeckService.test.ts
@@ -4,6 +4,7 @@
 
 import { Card } from '../../../../src/domain/entities';
 import * as DeckService from '../../../../src/domain/services/DeckService';
+import { SelectableDeck } from '../../../../src/domain/types/GameTypes';
 
 describe('DeckService', () => {
   describe('initializeDeck', () => {
@@ -301,11 +302,11 @@ describe('DeckService', () => {
   describe('sortDeckCards', () => {
     it('should sort deck cards in-place', () => {
       // Arrange
-      const deck: DeckService.SelectableDeck = {
+      const deck: SelectableDeck = {
         cards: [
-          { rank: 7, isJoker: false },
-          { rank: 3, isJoker: false },
-          { rank: 10, isJoker: false },
+          Card.fromPlainObject({ rank: 7, isJoker: false }),
+          Card.fromPlainObject({ rank: 3, isJoker: false }),
+          Card.fromPlainObject({ rank: 10, isJoker: false }),
         ],
         isSelected: false,
       };
@@ -314,9 +315,9 @@ describe('DeckService', () => {
       DeckService.sortDeckCards(deck);
 
       // Assert
-      expect(deck.cards[0].rank).toBe(3);
-      expect(deck.cards[1].rank).toBe(7);
-      expect(deck.cards[2].rank).toBe(10);
+      expect(deck.cards[0].toPlainObject().rank).toBe(3);
+      expect(deck.cards[1].toPlainObject().rank).toBe(7);
+      expect(deck.cards[2].toPlainObject().rank).toBe(10);
     });
   });
 
@@ -430,20 +431,20 @@ describe('DeckService', () => {
   describe('countTotalCards', () => {
     it('should count all cards across multiple decks', () => {
       // Arrange
-      const decks: DeckService.SelectableDeck[] = [
+      const decks: SelectableDeck[] = [
         {
           cards: [
-            { rank: 5, isJoker: false },
-            { rank: 7, isJoker: false },
+            Card.fromPlainObject({ rank: 5, isJoker: false }),
+            Card.fromPlainObject({ rank: 7, isJoker: false }),
           ],
           isSelected: false,
         },
-        { cards: [{ rank: 3, isJoker: false }], isSelected: false },
+        { cards: [Card.fromPlainObject({ rank: 3, isJoker: false })], isSelected: false },
         {
           cards: [
-            { rank: 1, isJoker: false },
-            { rank: 2, isJoker: false },
-            { rank: 4, isJoker: false },
+            Card.fromPlainObject({ rank: 1, isJoker: false }),
+            Card.fromPlainObject({ rank: 2, isJoker: false }),
+            Card.fromPlainObject({ rank: 4, isJoker: false }),
           ],
           isSelected: false,
         },
@@ -458,7 +459,7 @@ describe('DeckService', () => {
 
     it('should return 0 for empty decks array', () => {
       // Arrange
-      const decks: DeckService.SelectableDeck[] = [];
+      const decks: SelectableDeck[] = [];
 
       // Act
       const total = DeckService.countTotalCards(decks);
@@ -469,7 +470,7 @@ describe('DeckService', () => {
 
     it('should handle decks with no cards', () => {
       // Arrange
-      const decks: DeckService.SelectableDeck[] = [
+      const decks: SelectableDeck[] = [
         { cards: [], isSelected: false },
         { cards: [], isSelected: false },
       ];

--- a/server/__tests__/unit/domain/services/TaxService.test.ts
+++ b/server/__tests__/unit/domain/services/TaxService.test.ts
@@ -9,12 +9,7 @@ import * as TaxService from '../../../../src/domain/services/TaxService';
 /**
  * 테스트용 Helper: Player를 카드와 rank와 함께 생성
  */
-function createPlayerWithCards(
-  id: string,
-  nickname: string,
-  cards: Card[],
-  rank: number
-): Player {
+function createPlayerWithCards(id: string, nickname: string, cards: Card[], rank: number): Player {
   const player = Player.create(PlayerId.create(id), nickname);
   player.assignCards(cards);
   player.assignRank(rank);
@@ -290,7 +285,11 @@ describe('TaxService', () => {
           createPlayerWithCards(
             `player${i + 1}`,
             `Player${i + 1}`,
-            [Card.create((i % 13) + 1), Card.create(((i + 1) % 13) + 1), Card.create(((i + 5) % 13) + 1)],
+            [
+              Card.create((i % 13) + 1),
+              Card.create(((i + 1) % 13) + 1),
+              Card.create(((i + 5) % 13) + 1),
+            ],
             i + 1
           )
         );

--- a/server/__tests__/unit/domain/services/TaxService.test.ts
+++ b/server/__tests__/unit/domain/services/TaxService.test.ts
@@ -1,0 +1,434 @@
+/**
+ * TaxService Unit Tests
+ */
+
+import { Card, Player } from '../../../../src/domain/entities';
+import { PlayerId } from '../../../../src/domain/value-objects/PlayerId';
+import * as TaxService from '../../../../src/domain/services/TaxService';
+
+/**
+ * 테스트용 Helper: Player를 카드와 rank와 함께 생성
+ */
+function createPlayerWithCards(
+  id: string,
+  nickname: string,
+  cards: Card[],
+  rank: number
+): Player {
+  const player = Player.create(PlayerId.create(id), nickname);
+  player.assignCards(cards);
+  player.assignRank(rank);
+  return player;
+}
+
+describe('TaxService', () => {
+  describe('selectTaxCardsAutomatically', () => {
+    it('큰 숫자 카드(약한 카드)를 우선 선택해야 함 (selectLargest=true)', () => {
+      // Arrange
+      const cards = [
+        Card.create(3),
+        Card.create(7),
+        Card.create(1),
+        Card.create(10),
+        Card.create(5),
+      ];
+
+      // Act
+      const selected = TaxService.selectTaxCardsAutomatically(cards, 2, true);
+
+      // Assert
+      expect(selected).toHaveLength(2);
+      expect(selected[0].rank).toBe(10);
+      expect(selected[1].rank).toBe(7);
+    });
+
+    it('작은 숫자 카드(강한 카드)를 우선 선택해야 함 (selectLargest=false)', () => {
+      // Arrange
+      const cards = [
+        Card.create(3),
+        Card.create(7),
+        Card.create(1),
+        Card.create(10),
+        Card.create(5),
+      ];
+
+      // Act
+      const selected = TaxService.selectTaxCardsAutomatically(cards, 2, false);
+
+      // Assert
+      expect(selected).toHaveLength(2);
+      expect(selected[0].rank).toBe(1);
+      expect(selected[1].rank).toBe(3);
+    });
+
+    it('조커는 rank 13으로 취급하여 선택해야 함', () => {
+      // Arrange
+      const cards = [
+        Card.create(1),
+        Card.create(5),
+        Card.create(13, true), // 조커
+        Card.create(10),
+      ];
+
+      // Act - 큰 카드 선택
+      const selected = TaxService.selectTaxCardsAutomatically(cards, 2, true);
+
+      // Assert
+      expect(selected).toHaveLength(2);
+      expect(selected[0].isJoker).toBe(true); // 조커가 가장 약한 카드
+      expect(selected[1].rank).toBe(10);
+    });
+
+    it('요청된 count만큼만 카드를 선택해야 함', () => {
+      // Arrange
+      const cards = [Card.create(1), Card.create(5), Card.create(7), Card.create(10)];
+
+      // Act
+      const selected = TaxService.selectTaxCardsAutomatically(cards, 1, true);
+
+      // Assert
+      expect(selected).toHaveLength(1);
+      expect(selected[0].rank).toBe(10);
+    });
+
+    it('원본 배열을 변경하지 않아야 함', () => {
+      // Arrange
+      const cards = [Card.create(3), Card.create(1), Card.create(5)];
+      const originalLength = cards.length;
+
+      // Act
+      TaxService.selectTaxCardsAutomatically(cards, 2, true);
+
+      // Assert
+      expect(cards).toHaveLength(originalLength);
+    });
+  });
+
+  describe('initializeTaxExchanges', () => {
+    describe('4명 플레이어', () => {
+      it('1위와 4위가 2장씩 교환해야 함', () => {
+        // Arrange
+        const players = [
+          createPlayerWithCards(
+            'player1',
+            'Player1',
+            [Card.create(1), Card.create(2), Card.create(10), Card.create(11)],
+            1
+          ),
+          createPlayerWithCards('player2', 'Player2', [Card.create(3), Card.create(4)], 2),
+          createPlayerWithCards('player3', 'Player3', [Card.create(5), Card.create(6)], 3),
+          createPlayerWithCards(
+            'player4',
+            'Player4',
+            [Card.create(7), Card.create(8), Card.create(9), Card.create(12)],
+            4
+          ),
+        ];
+
+        const player1InitialCardCount = players[0].cards.length;
+        const player4InitialCardCount = players[3].cards.length;
+
+        // Act
+        const taxExchanges = TaxService.initializeTaxExchanges(players);
+
+        // Assert
+        expect(taxExchanges).toHaveLength(2);
+
+        // 4위 → 1위 교환 확인
+        const fromLastToFirst = taxExchanges.find(
+          (ex) => ex.fromPlayerId === 'player4' && ex.toPlayerId === 'player1'
+        );
+        expect(fromLastToFirst).toBeDefined();
+        expect(fromLastToFirst?.cardCount).toBe(2);
+        expect(fromLastToFirst?.cardsGiven).toHaveLength(2);
+
+        // 1위 → 4위 교환 확인
+        const fromFirstToLast = taxExchanges.find(
+          (ex) => ex.fromPlayerId === 'player1' && ex.toPlayerId === 'player4'
+        );
+        expect(fromFirstToLast).toBeDefined();
+        expect(fromFirstToLast?.cardCount).toBe(2);
+        expect(fromFirstToLast?.cardsGiven).toHaveLength(2);
+
+        // 플레이어 카드 개수가 동일해야 함
+        expect(players[0].cards.length).toBe(player1InitialCardCount);
+        expect(players[3].cards.length).toBe(player4InitialCardCount);
+      });
+
+      it('1등은 큰 숫자 카드를, 4등은 작은 숫자 카드를 주어야 함', () => {
+        // Arrange
+        const players = [
+          createPlayerWithCards(
+            'player1',
+            'Player1',
+            [Card.create(1), Card.create(2), Card.create(10), Card.create(11)],
+            1
+          ),
+          createPlayerWithCards('player2', 'Player2', [Card.create(3)], 2),
+          createPlayerWithCards('player3', 'Player3', [Card.create(4)], 3),
+          createPlayerWithCards(
+            'player4',
+            'Player4',
+            [Card.create(5), Card.create(6), Card.create(12), Card.create(13)],
+            4
+          ),
+        ];
+
+        // Act
+        const taxExchanges = TaxService.initializeTaxExchanges(players);
+
+        // Assert
+        const fromFirstToLast = taxExchanges.find(
+          (ex) => ex.fromPlayerId === 'player1' && ex.toPlayerId === 'player4'
+        );
+        // 1등은 큰 숫자(약한) 카드를 줌
+        expect(fromFirstToLast?.cardsGiven[0].rank).toBeGreaterThanOrEqual(10);
+        expect(fromFirstToLast?.cardsGiven[1].rank).toBeGreaterThanOrEqual(10);
+
+        const fromLastToFirst = taxExchanges.find(
+          (ex) => ex.fromPlayerId === 'player4' && ex.toPlayerId === 'player1'
+        );
+        // 4등은 작은 숫자(강한) 카드를 줌
+        expect(fromLastToFirst?.cardsGiven[0].rank).toBeLessThanOrEqual(6);
+        expect(fromLastToFirst?.cardsGiven[1].rank).toBeLessThanOrEqual(6);
+      });
+    });
+
+    describe('5명 이상 플레이어', () => {
+      it('5명: 1위↔꼴찌 2장, 2위↔차하위 1장 교환해야 함', () => {
+        // Arrange
+        const players = [
+          createPlayerWithCards(
+            'player1',
+            'Player1',
+            [Card.create(1), Card.create(2), Card.create(10)],
+            1
+          ),
+          createPlayerWithCards('player2', 'Player2', [Card.create(3), Card.create(11)], 2),
+          createPlayerWithCards('player3', 'Player3', [Card.create(4)], 3),
+          createPlayerWithCards('player4', 'Player4', [Card.create(5), Card.create(12)], 4),
+          createPlayerWithCards(
+            'player5',
+            'Player5',
+            [Card.create(6), Card.create(7), Card.create(13)],
+            5
+          ),
+        ];
+
+        // Act
+        const taxExchanges = TaxService.initializeTaxExchanges(players);
+
+        // Assert
+        expect(taxExchanges).toHaveLength(4);
+
+        // 5위 → 1위 2장
+        const from5to1 = taxExchanges.find(
+          (ex) => ex.fromPlayerId === 'player5' && ex.toPlayerId === 'player1'
+        );
+        expect(from5to1).toBeDefined();
+        expect(from5to1?.cardCount).toBe(2);
+
+        // 1위 → 5위 2장
+        const from1to5 = taxExchanges.find(
+          (ex) => ex.fromPlayerId === 'player1' && ex.toPlayerId === 'player5'
+        );
+        expect(from1to5).toBeDefined();
+        expect(from1to5?.cardCount).toBe(2);
+
+        // 4위 → 2위 1장
+        const from4to2 = taxExchanges.find(
+          (ex) => ex.fromPlayerId === 'player4' && ex.toPlayerId === 'player2'
+        );
+        expect(from4to2).toBeDefined();
+        expect(from4to2?.cardCount).toBe(1);
+
+        // 2위 → 4위 1장
+        const from2to4 = taxExchanges.find(
+          (ex) => ex.fromPlayerId === 'player2' && ex.toPlayerId === 'player4'
+        );
+        expect(from2to4).toBeDefined();
+        expect(from2to4?.cardCount).toBe(1);
+      });
+
+      it('6명 플레이어도 동일한 규칙이 적용되어야 함', () => {
+        // Arrange
+        const players = Array.from({ length: 6 }, (_, i) =>
+          createPlayerWithCards(
+            `player${i + 1}`,
+            `Player${i + 1}`,
+            [Card.create(i + 1), Card.create((i + 2) % 13 || 13), Card.create((i + 7) % 13 || 13)],
+            i + 1
+          )
+        );
+
+        // Act
+        const taxExchanges = TaxService.initializeTaxExchanges(players);
+
+        // Assert
+        expect(taxExchanges).toHaveLength(4);
+
+        // 1위 ↔ 6위 2장씩
+        expect(
+          taxExchanges.find((ex) => ex.fromPlayerId === 'player6' && ex.toPlayerId === 'player1')
+        ).toBeDefined();
+        expect(
+          taxExchanges.find((ex) => ex.fromPlayerId === 'player1' && ex.toPlayerId === 'player6')
+        ).toBeDefined();
+
+        // 2위 ↔ 5위 1장씩
+        expect(
+          taxExchanges.find((ex) => ex.fromPlayerId === 'player5' && ex.toPlayerId === 'player2')
+        ).toBeDefined();
+        expect(
+          taxExchanges.find((ex) => ex.fromPlayerId === 'player2' && ex.toPlayerId === 'player5')
+        ).toBeDefined();
+      });
+
+      it('8명 플레이어도 동일한 규칙이 적용되어야 함', () => {
+        // Arrange
+        const players = Array.from({ length: 8 }, (_, i) =>
+          createPlayerWithCards(
+            `player${i + 1}`,
+            `Player${i + 1}`,
+            [Card.create((i % 13) + 1), Card.create(((i + 1) % 13) + 1), Card.create(((i + 5) % 13) + 1)],
+            i + 1
+          )
+        );
+
+        // Act
+        const taxExchanges = TaxService.initializeTaxExchanges(players);
+
+        // Assert
+        expect(taxExchanges).toHaveLength(4);
+
+        // 1위 ↔ 8위 2장씩
+        expect(
+          taxExchanges.find((ex) => ex.fromPlayerId === 'player8' && ex.toPlayerId === 'player1')
+        ).toBeDefined();
+        expect(
+          taxExchanges.find((ex) => ex.fromPlayerId === 'player1' && ex.toPlayerId === 'player8')
+        ).toBeDefined();
+
+        // 2위 ↔ 7위 1장씩
+        expect(
+          taxExchanges.find((ex) => ex.fromPlayerId === 'player7' && ex.toPlayerId === 'player2')
+        ).toBeDefined();
+        expect(
+          taxExchanges.find((ex) => ex.fromPlayerId === 'player2' && ex.toPlayerId === 'player7')
+        ).toBeDefined();
+      });
+    });
+
+    describe('카드 교환 검증', () => {
+      it('플레이어의 실제 카드가 교환되어야 함', () => {
+        // Arrange
+        const players = [
+          createPlayerWithCards(
+            'player1',
+            'Player1',
+            [Card.create(1), Card.create(2), Card.create(10), Card.create(11)],
+            1
+          ),
+          createPlayerWithCards('player2', 'Player2', [Card.create(3)], 2),
+          createPlayerWithCards('player3', 'Player3', [Card.create(4)], 3),
+          createPlayerWithCards(
+            'player4',
+            'Player4',
+            [Card.create(5), Card.create(6), Card.create(12), Card.create(13)],
+            4
+          ),
+        ];
+
+        // Act
+        TaxService.initializeTaxExchanges(players);
+
+        // Assert
+        const player1 = players[0];
+        const player4 = players[3];
+
+        // 1등은 큰 카드(10, 11)를 주고 작은 카드(5, 6)를 받아야 함
+        expect(player1.cards.some((c) => c.rank === 5)).toBe(true);
+        expect(player1.cards.some((c) => c.rank === 6)).toBe(true);
+        expect(player1.cards.some((c) => c.rank === 10)).toBe(false);
+        expect(player1.cards.some((c) => c.rank === 11)).toBe(false);
+
+        // 4등은 작은 카드(5, 6)를 주고 큰 카드(10, 11)를 받아야 함
+        expect(player4.cards.some((c) => c.rank === 10)).toBe(true);
+        expect(player4.cards.some((c) => c.rank === 11)).toBe(true);
+        expect(player4.cards.some((c) => c.rank === 5)).toBe(false);
+        expect(player4.cards.some((c) => c.rank === 6)).toBe(false);
+      });
+
+      it('교환 후 플레이어의 총 카드 개수는 변하지 않아야 함', () => {
+        // Arrange
+        const players = [
+          createPlayerWithCards(
+            'player1',
+            'Player1',
+            [Card.create(1), Card.create(2), Card.create(10)],
+            1
+          ),
+          createPlayerWithCards('player2', 'Player2', [Card.create(3)], 2),
+          createPlayerWithCards('player3', 'Player3', [Card.create(4)], 3),
+          createPlayerWithCards(
+            'player4',
+            'Player4',
+            [Card.create(5), Card.create(6), Card.create(12)],
+            4
+          ),
+        ];
+
+        const initialCounts = players.map((p) => p.cards.length);
+
+        // Act
+        TaxService.initializeTaxExchanges(players);
+
+        // Assert
+        players.forEach((player, idx) => {
+          expect(player.cards.length).toBe(initialCounts[idx]);
+        });
+      });
+    });
+
+    describe('예외 케이스', () => {
+      it('플레이어가 3명 이하면 빈 배열을 반환해야 함', () => {
+        // Arrange
+        const players = [
+          createPlayerWithCards('player1', 'Player1', [Card.create(1)], 1),
+          createPlayerWithCards('player2', 'Player2', [Card.create(2)], 2),
+          createPlayerWithCards('player3', 'Player3', [Card.create(3)], 3),
+        ];
+
+        // Act
+        const taxExchanges = TaxService.initializeTaxExchanges(players);
+
+        // Assert
+        expect(taxExchanges).toHaveLength(0);
+      });
+
+      it('rank가 정렬되지 않은 플레이어도 올바르게 처리해야 함', () => {
+        // Arrange - rank 순서가 뒤섞인 플레이어
+        const players = [
+          createPlayerWithCards('player3', 'Player3', [Card.create(4)], 3),
+          createPlayerWithCards('player1', 'Player1', [Card.create(1), Card.create(10)], 1),
+          createPlayerWithCards('player4', 'Player4', [Card.create(5), Card.create(12)], 4),
+          createPlayerWithCards('player2', 'Player2', [Card.create(3)], 2),
+        ];
+
+        // Act
+        const taxExchanges = TaxService.initializeTaxExchanges(players);
+
+        // Assert
+        expect(taxExchanges).toHaveLength(2);
+
+        // 올바른 플레이어 간 교환이 이루어져야 함
+        expect(
+          taxExchanges.find((ex) => ex.fromPlayerId === 'player4' && ex.toPlayerId === 'player1')
+        ).toBeDefined();
+        expect(
+          taxExchanges.find((ex) => ex.fromPlayerId === 'player1' && ex.toPlayerId === 'player4')
+        ).toBeDefined();
+      });
+    });
+  });
+});

--- a/server/docs/INTERFACE_COMPATIBILITY_ANALYSIS.md
+++ b/server/docs/INTERFACE_COMPATIBILITY_ANALYSIS.md
@@ -1,0 +1,422 @@
+# Socket Interface Compatibility Analysis
+
+## 목적
+Phase 4에서 Hexagonal Architecture로 리팩토링한 신규 아키텍처가 기존 Legacy 서버와 **완전히 동일한 클라이언트 인터페이스**를 제공하는지 검증합니다.
+
+클라이언트 코드 수정 없이 서버만 교체 가능해야 합니다.
+
+---
+
+## 📊 Socket 이벤트 비교
+
+### Legacy (socket/SocketManager.ts)
+```typescript
+GET_GAME_STATE      ✅
+CREATE_GAME         ✅
+JOIN_GAME           ✅
+READY               ✅ (+ ALL_PLAYERS_READY 브로드캐스트)
+START_GAME          ❌ 누락
+SELECT_ROLE         ✅
+SELECT_DECK         ✅
+SELECT_REVOLUTION   ❌ 누락
+PLAY_CARD           ✅
+PASS                ✅
+VOTE                ✅
+disconnect          ✅
+```
+
+### New (src/presentation/socket/adapters/)
+```typescript
+GET_GAME_STATE      ✅
+CREATE_GAME         ✅
+JOIN_GAME           ✅
+LEAVE_GAME          ✅ (신규 추가)
+READY               ✅ (자동 시작 로직)
+SELECT_ROLE         ✅
+SELECT_DECK         ✅
+PLAY_CARD           ✅
+PASS                ✅
+VOTE                ✅
+disconnect          ✅ (자동 LEAVE_GAME 처리)
+```
+
+---
+
+## 🚨 Breaking Changes
+
+### 1. ✅ FIXED: GAME_STATE_UPDATED 브로드캐스트 형식
+
+#### Legacy
+```typescript
+this.io.to(roomId).emit('GAME_STATE_UPDATED', gameState);
+```
+
+#### New (Before Fix)
+```typescript
+this.io.to(roomId).emit('GAME_STATE_UPDATED', { game: gameState });
+// ❌ Breaking Change!
+```
+
+#### New (After Fix)
+```typescript
+this.io.to(roomId).emit('GAME_STATE_UPDATED', gameState);
+// ✅ Compatible!
+```
+
+**Status**: ✅ Fixed in BaseEventAdapter.ts
+
+---
+
+### 2. ❌ MISSING: START_GAME 이벤트
+
+#### Legacy 동작
+```typescript
+socket.on(SocketEvent.READY, async ({ roomId, playerId }, callback) => {
+  const game = await gameManager.setPlayerReady(roomId, playerId);
+
+  // 모든 플레이어가 준비되면 브로드캐스트
+  const allReady = game.players.every((p) => p.isReady);
+  if (allReady && game.players.length >= 2) {
+    this.io.to(roomId).emit(SocketEvent.ALL_PLAYERS_READY);
+  }
+
+  callback({ success: true });
+  this.emitGameState(roomId);
+});
+
+// 별도의 START_GAME 이벤트로 수동 시작
+socket.on(SocketEvent.START_GAME, async ({ roomId }, callback) => {
+  const success = await gameManager.startGame(roomId);
+  if (!success) {
+    callback({ success: false, error: '게임을 시작할 수 없습니다.' });
+    return;
+  }
+  callback({ success: true });
+  this.emitGameState(roomId);
+});
+```
+
+#### New 동작
+```typescript
+// toggleReadyAndCheckStart - 모든 플레이어가 준비되면 자동 시작
+socket.on(SocketEvent.READY, async ({ roomId }, callback) => {
+  const result = await commandService.toggleReadyAndCheckStart(roomId, socket.id);
+
+  await handleSocketEvent(result, callback, roomId);
+  // ❌ ALL_PLAYERS_READY 브로드캐스트 없음
+  // ✅ 자동 시작 (수동 START_GAME 불필요)
+});
+```
+
+**Impact**:
+- ❌ `START_GAME` 이벤트가 없어서 클라이언트가 수동으로 게임을 시작할 수 없음
+- ❌ `ALL_PLAYERS_READY` 브로드캐스트가 없어서 클라이언트가 모든 플레이어 준비 완료를 감지할 수 없음
+
+**Required Action**:
+1. `START_GAME` 이벤트 핸들러 추가 필요
+2. `ALL_PLAYERS_READY` 브로드캐스트 추가 필요
+3. 또는 클라이언트 로직 변경 (자동 시작 방식으로)
+
+---
+
+### 3. ❌ MISSING: SELECT_REVOLUTION 이벤트
+
+#### Legacy
+```typescript
+socket.on(SocketEvent.SELECT_REVOLUTION, async (
+  { roomId, playerId, wantRevolution },
+  callback
+) => {
+  const success = await gameManager.selectRevolution(
+    roomId,
+    playerId,
+    wantRevolution
+  );
+  if (!success) {
+    callback({ success: false, error: '혁명 선택에 실패했습니다.' });
+    return;
+  }
+  callback({ success: true });
+  this.emitGameState(roomId);
+});
+```
+
+#### New
+```typescript
+// ❌ SELECT_REVOLUTION 이벤트 핸들러 없음
+// ❌ SelectRevolutionUseCase 없음
+```
+
+**Impact**:
+- ❌ 혁명 선택 기능을 사용하는 클라이언트가 작동하지 않음
+
+**Required Action**:
+1. `SelectRevolutionUseCase` 추가
+2. `RoleSelectionEventAdapter`에 `SELECT_REVOLUTION` 핸들러 추가
+3. GameCommandService에 메서드 추가
+
+---
+
+## ✅ 추가된 기능 (Backward Compatible)
+
+### 1. LEAVE_GAME 이벤트
+
+#### New
+```typescript
+socket.on(SocketEvent.LEAVE_GAME, async ({ roomId }, callback) => {
+  const result = await commandService.leaveGame(roomId, socket.id);
+
+  await handleSocketEvent(result, callback, roomId, async () => {
+    socket.leave(roomId);
+    playerRooms.delete(socket.id);
+  });
+});
+```
+
+**Impact**: ✅ 클라이언트가 호출하지 않으면 영향 없음 (Backward Compatible)
+
+**Benefit**: 플레이어가 명시적으로 게임을 나갈 수 있음
+
+---
+
+### 2. disconnect 자동 처리
+
+#### Legacy
+```typescript
+socket.on('disconnect', () => {
+  console.log('클라이언트가 연결을 끊었습니다:', socket.id);
+  // ❌ 아무 처리도 하지 않음
+});
+```
+
+#### New
+```typescript
+socket.on('disconnect', async () => {
+  const roomId = playerRooms.get(socket.id);
+  if (roomId) {
+    try {
+      const result = await commandService.leaveGame(roomId, socket.id);
+      if (result.success) {
+        await emitGameState(roomId);
+      }
+    } catch (error) {
+      console.error('Disconnect 처리 중 오류:', error);
+    }
+  }
+});
+```
+
+**Impact**: ✅ 개선 (플레이어가 비정상 종료해도 게임에서 자동 제거)
+
+---
+
+## 📝 Request/Response 형식 비교
+
+### Request 페이로드
+
+#### READY 이벤트 차이
+
+**Legacy**:
+```typescript
+{ roomId: string; playerId: string }
+```
+
+**New**:
+```typescript
+{ roomId: string }
+// socket.id를 자동으로 사용
+```
+
+**Impact**:
+- ⚠️ 클라이언트가 `playerId` 필드를 보내도 무시됨
+- ✅ 하지만 에러는 발생하지 않음 (Backward Compatible)
+
+#### SELECT_ROLE 이벤트 차이
+
+**Legacy**:
+```typescript
+{ roomId: string; playerId: string; roleNumber: number }
+```
+
+**New**:
+```typescript
+{ roomId: string; roleNumber: number }
+// socket.id를 자동으로 사용
+```
+
+**Impact**: 동일
+
+#### PLAY_CARD 이벤트 차이
+
+**Legacy**:
+```typescript
+{ roomId: string; playerId: string; cards: Card[] }
+```
+
+**New**:
+```typescript
+{ roomId: string; cards: Card[] }
+// socket.id를 자동으로 사용
+```
+
+**Impact**: 동일
+
+#### PASS 이벤트 차이
+
+**Legacy**:
+```typescript
+{ roomId: string; playerId: string }
+```
+
+**New**:
+```typescript
+{ roomId: string }
+// socket.id를 자동으로 사용
+```
+
+**Impact**: 동일
+
+**Summary**:
+- ✅ playerId를 명시적으로 보내지 않아도 동작함 (socket.id 사용)
+- ✅ 클라이언트가 playerId를 보내도 무시될 뿐 에러는 없음
+
+---
+
+### Response 형식
+
+#### 모든 이벤트 공통
+
+**Legacy**:
+```typescript
+{
+  success: boolean;
+  data?: any;
+  error?: string;
+}
+```
+
+**New**:
+```typescript
+{
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+```
+
+**Impact**: ✅ 완전히 동일
+
+#### CREATE_GAME Response Data
+
+**Legacy**:
+```typescript
+{
+  success: true,
+  data: { roomId: string; nickname: string }
+}
+```
+
+**New**:
+```typescript
+{
+  success: true,
+  data: { roomId: string; playerId: string; playerCount: number }
+}
+```
+
+**Impact**:
+- ⚠️ 필드명이 다름 (`nickname` → `playerId`, `playerCount` 추가)
+- ⚠️ 클라이언트가 `nickname` 필드를 참조하면 undefined
+
+**Required Action**: Response DTO 형식 통일 필요
+
+---
+
+## 🎯 호환성 요약
+
+### ✅ Compatible (수정 완료)
+- [x] GAME_STATE_UPDATED 브로드캐스트 형식
+- [x] Response 형식 (success/data/error)
+- [x] 대부분의 이벤트 핸들러
+
+### ⚠️ Partially Compatible
+- [ ] playerId 파라미터 (보내도 무시될 뿐 에러 없음)
+- [ ] CREATE_GAME response data 필드명
+
+### ❌ Breaking Changes (수정 필요)
+- [ ] START_GAME 이벤트 누락
+- [ ] ALL_PLAYERS_READY 브로드캐스트 누락
+- [ ] SELECT_REVOLUTION 이벤트 누락
+
+---
+
+## 📋 조치 필요 사항
+
+### High Priority (클라이언트가 사용 중인 기능)
+1. **START_GAME 이벤트 추가**
+   - Use Case: StartGameUseCase (이미 존재하는지 확인 필요)
+   - Adapter: GameEventAdapter에 핸들러 추가
+
+2. **ALL_PLAYERS_READY 브로드캐스트 추가**
+   - ReadyGameUseCase에서 조건 체크
+   - 모든 플레이어 준비 완료 시 브로드캐스트
+
+3. **SELECT_REVOLUTION 이벤트 추가**
+   - Use Case: SelectRevolutionUseCase 구현
+   - Adapter: RoleSelectionEventAdapter에 핸들러 추가
+
+### Medium Priority (데이터 형식 통일)
+4. **CREATE_GAME Response 형식 통일**
+   - Legacy: `{ roomId, nickname }`
+   - New: `{ roomId, playerId, playerCount }`
+   - 결정 필요: 어느 형식을 사용할지
+
+### Low Priority (개선 사항)
+5. **문서화**
+   - Socket 이벤트 API 명세서 작성
+   - 클라이언트-서버 인터페이스 계약 문서화
+
+---
+
+## 🧪 검증 계획
+
+### 1. Unit Tests
+- [ ] 각 Adapter의 이벤트 핸들러 테스트
+- [ ] Response 형식 검증 테스트
+
+### 2. Integration Tests
+- [ ] Legacy SocketManager vs New SocketCoordinator 동작 비교
+- [ ] 동일한 입력에 대한 동일한 출력 검증
+
+### 3. E2E Tests
+- [ ] 전체 게임 플로우 테스트
+  - 대기실 → 준비 → 시작 → 역할 선택 → 카드 선택 → 게임 플레이 → 종료
+- [ ] 멀티플레이어 시나리오
+- [ ] 에러 케이스
+
+### 4. Client Compatibility Tests
+- [ ] 기존 클라이언트 코드와 연동 테스트
+- [ ] Breaking Change 없이 서버 교체 가능 검증
+
+---
+
+## 📅 작업 우선순위
+
+1. **즉시** (Phase 5-1): Breaking Changes 수정
+   - START_GAME 이벤트 추가
+   - ALL_PLAYERS_READY 브로드캐스트 추가
+   - SELECT_REVOLUTION 이벤트 추가
+
+2. **Phase 5-1**: E2E 테스트 작성 및 검증
+   - 전체 게임 플로우 테스트
+   - 클라이언트 호환성 검증
+
+3. **Phase 5-2**: 마이그레이션 완료
+   - Legacy 코드 제거
+   - 문서화 완료
+
+---
+
+**작성일**: 2025-11-15
+**작성자**: Claude Code
+**검토 필요**: 모든 Breaking Changes 수정 후 재검증

--- a/server/server.ts
+++ b/server/server.ts
@@ -15,8 +15,10 @@ import { CreateGameUseCase } from './src/application/use-cases/game/CreateGameUs
 import { JoinGameUseCase } from './src/application/use-cases/game/JoinGameUseCase';
 import { LeaveGameUseCase } from './src/application/use-cases/game/LeaveGameUseCase';
 import { ReadyGameUseCase } from './src/application/use-cases/game/ReadyGameUseCase';
+import { StartGameUseCase } from './src/application/use-cases/game/StartGameUseCase';
 import { SelectRoleUseCase } from './src/application/use-cases/game/SelectRoleUseCase';
 import { SelectDeckUseCase } from './src/application/use-cases/game/SelectDeckUseCase';
+import { SelectRevolutionUseCase } from './src/application/use-cases/game/SelectRevolutionUseCase';
 import { PlayCardUseCase } from './src/application/use-cases/game/PlayCardUseCase';
 import { PassTurnUseCase } from './src/application/use-cases/game/PassTurnUseCase';
 import { VoteNextGameUseCase } from './src/application/use-cases/game/VoteNextGameUseCase';
@@ -55,8 +57,10 @@ const createGameUseCase = new CreateGameUseCase(gameRepository);
 const joinGameUseCase = new JoinGameUseCase(gameRepository);
 const leaveGameUseCase = new LeaveGameUseCase(gameRepository);
 const readyGameUseCase = new ReadyGameUseCase(gameRepository);
+const startGameUseCase = new StartGameUseCase(gameRepository);
 const selectRoleUseCase = new SelectRoleUseCase(gameRepository);
 const selectDeckUseCase = new SelectDeckUseCase(gameRepository);
+const selectRevolutionUseCase = new SelectRevolutionUseCase(gameRepository);
 const playCardUseCase = new PlayCardUseCase(gameRepository);
 const passTurnUseCase = new PassTurnUseCase(gameRepository);
 const voteNextGameUseCase = new VoteNextGameUseCase(gameRepository);
@@ -69,8 +73,10 @@ const gameCommandService = new GameCommandService(
   joinGameUseCase,
   leaveGameUseCase,
   readyGameUseCase,
+  startGameUseCase,
   selectRoleUseCase,
   selectDeckUseCase,
+  selectRevolutionUseCase,
   playCardUseCase,
   passTurnUseCase,
   voteNextGameUseCase,

--- a/server/src/application/dto/game/SelectRevolutionDto.ts
+++ b/server/src/application/dto/game/SelectRevolutionDto.ts
@@ -1,0 +1,29 @@
+/**
+ * SelectRevolutionDto.ts
+ *
+ * 혁명 선택 요청/응답 DTO
+ */
+
+/**
+ * 혁명 선택 요청 DTO
+ */
+export interface SelectRevolutionRequest {
+  roomId: string;
+  playerId: string;
+  wantRevolution: boolean;
+}
+
+/**
+ * 혁명 선택 응답 DTO
+ */
+export interface SelectRevolutionResponse {
+  roomId: string;
+  playerId: string;
+  wantRevolution: boolean;
+  phase: string;
+  revolutionStatus?: {
+    isRevolution: boolean;
+    isGreatRevolution: boolean;
+    revolutionPlayerId: string;
+  };
+}

--- a/server/src/application/dto/game/StartGameDto.ts
+++ b/server/src/application/dto/game/StartGameDto.ts
@@ -1,0 +1,21 @@
+/**
+ * StartGameDto.ts
+ *
+ * 게임 시작 요청/응답 DTO
+ */
+
+/**
+ * 게임 시작 요청 DTO
+ */
+export interface StartGameRequest {
+  roomId: string;
+}
+
+/**
+ * 게임 시작 응답 DTO
+ */
+export interface StartGameResponse {
+  roomId: string;
+  phase: string;
+  playerCount: number;
+}

--- a/server/src/application/services/GameCommandService.ts
+++ b/server/src/application/services/GameCommandService.ts
@@ -14,8 +14,10 @@ import { CreateGameUseCase } from '../use-cases/game/CreateGameUseCase';
 import { JoinGameUseCase } from '../use-cases/game/JoinGameUseCase';
 import { LeaveGameUseCase } from '../use-cases/game/LeaveGameUseCase';
 import { ReadyGameUseCase } from '../use-cases/game/ReadyGameUseCase';
+import { StartGameUseCase } from '../use-cases/game/StartGameUseCase';
 import { SelectRoleUseCase } from '../use-cases/game/SelectRoleUseCase';
 import { SelectDeckUseCase } from '../use-cases/game/SelectDeckUseCase';
+import { SelectRevolutionUseCase } from '../use-cases/game/SelectRevolutionUseCase';
 import { PlayCardUseCase } from '../use-cases/game/PlayCardUseCase';
 import { PassTurnUseCase } from '../use-cases/game/PassTurnUseCase';
 import { VoteNextGameUseCase } from '../use-cases/game/VoteNextGameUseCase';
@@ -38,8 +40,10 @@ export class GameCommandService {
     private readonly joinGameUseCase: JoinGameUseCase,
     private readonly leaveGameUseCase: LeaveGameUseCase,
     private readonly readyGameUseCase: ReadyGameUseCase,
+    private readonly startGameUseCase: StartGameUseCase,
     private readonly selectRoleUseCase: SelectRoleUseCase,
     private readonly selectDeckUseCase: SelectDeckUseCase,
+    private readonly selectRevolutionUseCase: SelectRevolutionUseCase,
     private readonly playCardUseCase: PlayCardUseCase,
     private readonly passTurnUseCase: PassTurnUseCase,
     private readonly voteNextGameUseCase: VoteNextGameUseCase,
@@ -276,6 +280,23 @@ export class GameCommandService {
   }
 
   /**
+   * 게임 시작
+   *
+   * 대기 중인 게임을 시작하여 역할 선택 단계로 진입합니다.
+   * - 플레이어 수 검증 (4-8명)
+   * - 덱 및 역할 선택 카드 초기화
+   * - phase를 'roleSelection'으로 변경
+   *
+   * @param roomId - 방 ID
+   * @returns 게임 시작 결과
+   */
+  async startGame(roomId: string) {
+    return this.startGameUseCase.execute({
+      roomId,
+    });
+  }
+
+  /**
    * 역할 선택
    *
    * 플레이어가 역할(순위)을 선택합니다.
@@ -308,6 +329,26 @@ export class GameCommandService {
       roomId,
       playerId,
       deckIndex,
+    });
+  }
+
+  /**
+   * 혁명 선택
+   *
+   * 조커 2장 보유 플레이어가 혁명 여부를 선택합니다.
+   * - 혁명 선택 시: 대혁명(꼴찌면 순위 반전) 또는 일반혁명 → playing 페이즈
+   * - 혁명 거부 시: 세금 교환 → tax 페이즈
+   *
+   * @param roomId - 방 ID
+   * @param playerId - 플레이어 ID
+   * @param wantRevolution - 혁명 여부 (true: 혁명, false: 거부)
+   * @returns 혁명 선택 결과
+   */
+  async selectRevolution(roomId: string, playerId: string, wantRevolution: boolean) {
+    return this.selectRevolutionUseCase.execute({
+      roomId,
+      playerId,
+      wantRevolution,
     });
   }
 

--- a/server/src/application/use-cases/game/SelectDeckUseCase.ts
+++ b/server/src/application/use-cases/game/SelectDeckUseCase.ts
@@ -110,6 +110,16 @@ export class SelectDeckUseCase
           );
           game.incrementRound();
         }
+      } else {
+        // 아직 모든 덱이 선택되지 않았다면 다음 플레이어에게 턴을 넘김
+        const sortedPlayers = game.players.slice().sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+        const nextPlayer = sortedPlayers.find(
+          (p) => !game.selectableDecks?.some((d) => d.selectedBy === p.id.value)
+        );
+
+        if (nextPlayer) {
+          game.setCurrentTurn(nextPlayer.id);
+        }
       }
 
       // 5. 변경사항 영속화

--- a/server/src/application/use-cases/game/SelectDeckUseCase.ts
+++ b/server/src/application/use-cases/game/SelectDeckUseCase.ts
@@ -101,14 +101,7 @@ export class SelectDeckUseCase
         } else {
           // 조커 2장 보유자가 없으면 바로 세금 교환
           const taxExchanges = TaxService.initializeTaxExchanges(game.players);
-          game.setTaxExchanges(taxExchanges);
-          game.changePhase('tax');
-
-          // 세금 교환 후 게임 시작 준비
-          game.setCurrentTurn(
-            game.players.slice().sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))[0].id
-          );
-          game.incrementRound();
+          game.prepareForTaxPhase(taxExchanges);
         }
       } else {
         // 아직 모든 덱이 선택되지 않았다면 다음 플레이어에게 턴을 넘김

--- a/server/src/application/use-cases/game/SelectDeckUseCase.ts
+++ b/server/src/application/use-cases/game/SelectDeckUseCase.ts
@@ -26,6 +26,7 @@ import {
   ValidationError,
   BusinessRuleError,
 } from '../../errors/ApplicationError';
+import * as TaxService from '../../../domain/services/TaxService';
 
 /**
  * SelectDeckUseCase
@@ -86,10 +87,35 @@ export class SelectDeckUseCase
       // 선택된 덱의 카드 정보 변환
       const selectedCards = selectedDeck.cards.map((card) => card.toPlainObject());
 
-      // 4. 변경사항 영속화
+      // 4. 모든 덱이 선택되었는지 확인
+      const allDecksSelected = game.selectableDecks?.every((deck) => deck.isSelected) ?? false;
+
+      if (allDecksSelected) {
+        // 조커 2장 보유자 확인
+        const doubleJokerPlayer = game.checkDoubleJoker();
+
+        if (doubleJokerPlayer) {
+          // 조커 2장 보유자가 있으면 혁명 선택 페이즈로
+          game.changePhase('revolution');
+          game.setCurrentTurn(doubleJokerPlayer.id);
+        } else {
+          // 조커 2장 보유자가 없으면 바로 세금 교환
+          const taxExchanges = TaxService.initializeTaxExchanges(game.players);
+          game.setTaxExchanges(taxExchanges);
+          game.changePhase('tax');
+
+          // 세금 교환 후 게임 시작 준비
+          game.setCurrentTurn(
+            game.players.slice().sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))[0].id
+          );
+          game.incrementRound();
+        }
+      }
+
+      // 5. 변경사항 영속화
       await this.gameRepository.update(roomId, game);
 
-      // 5. Response DTO 반환
+      // 6. Response DTO 반환
       return createSuccessResponse<SelectDeckResponse>({
         roomId: game.roomId.value,
         playerId: playerId.value,

--- a/server/src/application/use-cases/game/SelectRevolutionUseCase.ts
+++ b/server/src/application/use-cases/game/SelectRevolutionUseCase.ts
@@ -1,0 +1,104 @@
+/**
+ * SelectRevolutionUseCase.ts
+ *
+ * 혁명 선택 유스케이스
+ *
+ * 책임:
+ * 1. RoomId, PlayerId Value Object 변환
+ * 2. Game Entity 조회
+ * 3. 혁명 선택 처리 (Game Entity의 processRevolutionChoice 호출)
+ * 4. Repository를 통한 업데이트
+ * 5. Response DTO 반환
+ */
+
+import { IUseCase } from '../base/IUseCase';
+import { IGameRepository } from '../../ports/IGameRepository';
+import { RoomId } from '../../../domain/value-objects/RoomId';
+import { PlayerId } from '../../../domain/value-objects/PlayerId';
+import {
+  SelectRevolutionRequest,
+  SelectRevolutionResponse,
+} from '../../dto/game/SelectRevolutionDto';
+import {
+  UseCaseResponse,
+  createSuccessResponse,
+  createErrorResponse,
+} from '../../dto/common/BaseResponse';
+import {
+  ResourceNotFoundError,
+  ValidationError,
+  BusinessRuleError,
+} from '../../errors/ApplicationError';
+
+/**
+ * SelectRevolutionUseCase
+ *
+ * 조커 2장 보유 플레이어가 혁명 여부를 선택합니다.
+ * - 혁명 선택 시: 대혁명(꼴찌면 순위 반전) 또는 일반혁명 → playing 페이즈
+ * - 혁명 거부 시: 세금 교환 → tax 페이즈
+ */
+export class SelectRevolutionUseCase
+  implements IUseCase<SelectRevolutionRequest, UseCaseResponse<SelectRevolutionResponse>>
+{
+  constructor(private readonly gameRepository: IGameRepository) {}
+
+  async execute(
+    request: SelectRevolutionRequest
+  ): Promise<UseCaseResponse<SelectRevolutionResponse>> {
+    try {
+      // 1. Value Object 변환
+      let roomId: RoomId;
+      let playerId: PlayerId;
+
+      try {
+        roomId = RoomId.from(request.roomId);
+        playerId = PlayerId.create(request.playerId);
+      } catch (error) {
+        throw new ValidationError(
+          error instanceof Error ? error.message : 'Invalid request parameters',
+          'roomId or playerId'
+        );
+      }
+
+      // 2. Game Entity 조회
+      const game = await this.gameRepository.findById(roomId);
+      if (!game) {
+        throw new ResourceNotFoundError('Game', roomId.value);
+      }
+
+      // 3. 혁명 선택 처리 (Game Entity에 위임)
+      game.processRevolutionChoice(playerId, request.wantRevolution);
+
+      // 4. Repository를 통해 업데이트
+      await this.gameRepository.update(roomId, game);
+
+      // 5. Response DTO 반환
+      return createSuccessResponse<SelectRevolutionResponse>({
+        roomId: game.roomId.value,
+        playerId: playerId.value,
+        wantRevolution: request.wantRevolution,
+        phase: game.phase,
+        revolutionStatus: game.revolutionStatus,
+      });
+    } catch (error) {
+      // Application Layer 에러는 그대로 전달
+      if (
+        error instanceof ValidationError ||
+        error instanceof ResourceNotFoundError ||
+        error instanceof BusinessRuleError
+      ) {
+        return createErrorResponse(
+          error.code,
+          error.message,
+          error instanceof ValidationError ? { field: error.field } : undefined
+        );
+      }
+
+      // 예상치 못한 에러
+      return createErrorResponse(
+        'SELECT_REVOLUTION_FAILED',
+        error instanceof Error ? error.message : 'Unknown error occurred'
+      );
+    }
+  }
+}

--- a/server/src/application/use-cases/game/SelectRevolutionUseCase.ts
+++ b/server/src/application/use-cases/game/SelectRevolutionUseCase.ts
@@ -72,16 +72,9 @@ export class SelectRevolutionUseCase
 
       // 4. 혁명 거부 시 세금 교환 수행
       if (!request.wantRevolution) {
-        // Domain Service를 통해 세금 교환 처리
+        // TaxService를 통해 세금 교환 초기화 후 Game 엔티티에 설정
         const taxExchanges = TaxService.initializeTaxExchanges(game.players);
-        game.setTaxExchanges(taxExchanges);
-
-        // 세금 교환 후 playing 페이즈로 전환 준비
-        // (Legacy에서는 10초 타이머 사용, 여기서는 클라이언트에서 처리)
-        game.setCurrentTurn(
-          game.players.slice().sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))[0].id
-        );
-        game.incrementRound();
+        game.prepareForTaxPhase(taxExchanges);
       }
 
       // 5. Repository를 통해 업데이트

--- a/server/src/application/use-cases/game/SelectRevolutionUseCase.ts
+++ b/server/src/application/use-cases/game/SelectRevolutionUseCase.ts
@@ -78,7 +78,9 @@ export class SelectRevolutionUseCase
 
         // 세금 교환 후 playing 페이즈로 전환 준비
         // (Legacy에서는 10초 타이머 사용, 여기서는 클라이언트에서 처리)
-        game.setCurrentTurn(game.players.slice().sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))[0].id);
+        game.setCurrentTurn(
+          game.players.slice().sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))[0].id
+        );
         game.incrementRound();
       }
 

--- a/server/src/application/use-cases/game/StartGameUseCase.ts
+++ b/server/src/application/use-cases/game/StartGameUseCase.ts
@@ -1,0 +1,125 @@
+/**
+ * StartGameUseCase.ts
+ *
+ * 게임 시작 유스케이스
+ *
+ * 책임:
+ * 1. RoomId Value Object 변환
+ * 2. Game Entity 조회
+ * 3. 플레이어 수 검증 (MIN_PLAYERS ~ MAX_PLAYERS)
+ * 4. 덱 및 역할 선택 카드 초기화
+ * 5. phase를 'roleSelection'으로 변경
+ * 6. Repository를 통한 업데이트
+ * 7. Response DTO 반환
+ */
+
+import { IUseCase } from '../base/IUseCase';
+import { IGameRepository } from '../../ports/IGameRepository';
+import { RoomId } from '../../../domain/value-objects/RoomId';
+import { StartGameRequest, StartGameResponse } from '../../dto/game/StartGameDto';
+import {
+  UseCaseResponse,
+  createSuccessResponse,
+  createErrorResponse,
+} from '../../dto/common/BaseResponse';
+import { ResourceNotFoundError, ValidationError, BusinessRuleError } from '../../errors/ApplicationError';
+import * as DeckService from '../../../domain/services/DeckService';
+import { Card } from '../../../domain/entities/Card';
+
+/**
+ * StartGameUseCase
+ *
+ * 대기 중인 게임을 시작하여 역할 선택 단계로 진입합니다.
+ */
+export class StartGameUseCase
+  implements IUseCase<StartGameRequest, UseCaseResponse<StartGameResponse>>
+{
+  private readonly MIN_PLAYERS = 4;
+  private readonly MAX_PLAYERS = 8;
+
+  constructor(private readonly gameRepository: IGameRepository) {}
+
+  async execute(request: StartGameRequest): Promise<UseCaseResponse<StartGameResponse>> {
+    try {
+      // 1. Value Object 변환
+      let roomId: RoomId;
+
+      try {
+        roomId = RoomId.from(request.roomId);
+      } catch (error) {
+        throw new ValidationError(
+          error instanceof Error ? error.message : 'Invalid room ID format',
+          'roomId'
+        );
+      }
+
+      // 2. Game Entity 조회
+      const game = await this.gameRepository.findById(roomId);
+      if (!game) {
+        throw new ResourceNotFoundError('Game', roomId.value);
+      }
+
+      // 3. 플레이어 수 검증
+      const playerCount = game.players.length;
+      if (playerCount < this.MIN_PLAYERS || playerCount > this.MAX_PLAYERS) {
+        throw new BusinessRuleError(
+          `게임을 시작하려면 ${this.MIN_PLAYERS}~${this.MAX_PLAYERS}명의 플레이어가 필요합니다. 현재: ${playerCount}명`
+        );
+      }
+
+      // 4. phase 검증 (waiting 단계에서만 시작 가능)
+      if (game.phase !== 'waiting') {
+        throw new BusinessRuleError(
+          `대기 중인 게임만 시작할 수 있습니다. 현재 상태: ${game.phase}`
+        );
+      }
+
+      // 5. 덱 초기화
+      const standardDeck = DeckService.initializeDeck();
+      const shuffledDeck = DeckService.shuffleDeck(standardDeck);
+
+      // Card Value Object로 변환
+      const deckCards = shuffledDeck.map((cardPlain) =>
+        Card.create(cardPlain.rank, cardPlain.isJoker)
+      );
+
+      game.setDeck(deckCards);
+
+      // 6. 역할 선택 카드 초기화
+      const roleSelectionCards = DeckService.createRoleSelectionDeck();
+      game.setRoleSelectionCards(roleSelectionCards);
+
+      // 7. phase를 'roleSelection'으로 변경
+      game.changePhase('roleSelection');
+
+      // 8. Repository를 통해 업데이트
+      await this.gameRepository.update(roomId, game);
+
+      // 9. Response DTO 반환
+      return createSuccessResponse<StartGameResponse>({
+        roomId: game.roomId.value,
+        phase: game.phase,
+        playerCount: game.players.length,
+      });
+    } catch (error) {
+      // Application Layer 에러는 그대로 전달
+      if (
+        error instanceof ValidationError ||
+        error instanceof ResourceNotFoundError ||
+        error instanceof BusinessRuleError
+      ) {
+        return createErrorResponse(
+          error.code,
+          error.message,
+          error instanceof ValidationError ? { field: error.field } : undefined
+        );
+      }
+
+      // 예상치 못한 에러
+      return createErrorResponse(
+        'START_GAME_FAILED',
+        error instanceof Error ? error.message : 'Unknown error occurred'
+      );
+    }
+  }
+}

--- a/server/src/application/use-cases/game/StartGameUseCase.ts
+++ b/server/src/application/use-cases/game/StartGameUseCase.ts
@@ -22,7 +22,11 @@ import {
   createSuccessResponse,
   createErrorResponse,
 } from '../../dto/common/BaseResponse';
-import { ResourceNotFoundError, ValidationError, BusinessRuleError } from '../../errors/ApplicationError';
+import {
+  ResourceNotFoundError,
+  ValidationError,
+  BusinessRuleError,
+} from '../../errors/ApplicationError';
 import * as DeckService from '../../../domain/services/DeckService';
 import { Card } from '../../../domain/entities/Card';
 

--- a/server/src/domain/entities/Game.ts
+++ b/server/src/domain/entities/Game.ts
@@ -158,6 +158,36 @@ export class Game {
   }
 
   /**
+   * 세금 교환 페이즈 준비
+   *
+   * 세금 교환을 설정하고 tax 페이즈로 전환합니다.
+   * 다음 라운드 시작 플레이어(rank 1)를 턴으로 설정하고 라운드를 증가시킵니다.
+   *
+   * SelectDeckUseCase와 SelectRevolutionUseCase에서 공통으로 사용됩니다.
+   *
+   * @param taxExchanges 세금 교환 정보 (Use Case에서 TaxService를 통해 생성)
+   */
+  prepareForTaxPhase(taxExchanges: TaxExchange[]): void {
+    // 세금 교환 설정
+    this.setTaxExchanges(taxExchanges);
+
+    // tax 페이즈로 전환
+    this.changePhase('tax');
+
+    // 첫 번째 순위 플레이어(rank 1)를 턴으로 설정
+    const firstRankPlayer = this._players
+      .slice()
+      .sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))[0];
+
+    if (firstRankPlayer) {
+      this.setCurrentTurn(firstRankPlayer.id);
+    }
+
+    // 라운드 증가
+    this.incrementRound();
+  }
+
+  /**
    * 플레이어가 카드를 낼 수 있는지 확인
    * @param playerId 플레이어 ID
    * @param cards 낼 카드들

--- a/server/src/domain/entities/Game.ts
+++ b/server/src/domain/entities/Game.ts
@@ -34,6 +34,12 @@ export class Game {
 
   private _votes: Map<string, boolean>; // playerId → vote (true: 찬성, false: 반대)
 
+  private _revolutionStatus?: {
+    isRevolution: boolean;
+    isGreatRevolution: boolean;
+    revolutionPlayerId: string;
+  }; // 혁명 상태
+
   /**
    * Private constructor - factory method를 통해서만 생성 가능
    */
@@ -48,7 +54,12 @@ export class Game {
     finishedPlayers: PlayerId[] = [],
     selectableDecks?: SelectableDeck[],
     roleSelectionCards?: RoleSelectionCard[],
-    votes: Map<string, boolean> = new Map()
+    votes: Map<string, boolean> = new Map(),
+    revolutionStatus?: {
+      isRevolution: boolean;
+      isGreatRevolution: boolean;
+      revolutionPlayerId: string;
+    }
   ) {
     this.roomId = roomId;
     this._players = players;
@@ -61,6 +72,7 @@ export class Game {
     this._selectableDecks = selectableDecks;
     this._roleSelectionCards = roleSelectionCards;
     this._votes = votes;
+    this._revolutionStatus = revolutionStatus;
   }
 
   /**
@@ -107,6 +119,27 @@ export class Game {
 
   get roleSelectionCards(): RoleSelectionCard[] | undefined {
     return this._roleSelectionCards ? [...this._roleSelectionCards] : undefined;
+  }
+
+  get revolutionStatus():
+    | {
+        isRevolution: boolean;
+        isGreatRevolution: boolean;
+        revolutionPlayerId: string;
+      }
+    | undefined {
+    return this._revolutionStatus;
+  }
+
+  /**
+   * 혁명 상태 설정
+   */
+  setRevolutionStatus(status: {
+    isRevolution: boolean;
+    isGreatRevolution: boolean;
+    revolutionPlayerId: string;
+  }): void {
+    this._revolutionStatus = status;
   }
 
   /**
@@ -509,6 +542,11 @@ export class Game {
     }>;
     roleSelectionCards?: RoleSelectionCard[];
     votes: Record<string, boolean>;
+    revolutionStatus?: {
+      isRevolution: boolean;
+      isGreatRevolution: boolean;
+      revolutionPlayerId: string;
+    };
   } {
     // Map을 Record로 변환
     const votesRecord: Record<string, boolean> = Object.fromEntries(this._votes);
@@ -536,6 +574,7 @@ export class Game {
         : undefined,
       roleSelectionCards: this._roleSelectionCards,
       votes: votesRecord,
+      revolutionStatus: this._revolutionStatus,
     };
   }
 
@@ -558,6 +597,11 @@ export class Game {
     }>;
     roleSelectionCards?: RoleSelectionCard[];
     votes?: Record<string, boolean>;
+    revolutionStatus?: {
+      isRevolution: boolean;
+      isGreatRevolution: boolean;
+      revolutionPlayerId: string;
+    };
   }): Game {
     const players = obj.players ? obj.players.map((p) => Player.fromPlainObject(p)) : [];
 
@@ -597,7 +641,8 @@ export class Game {
       finishedPlayers,
       selectableDecks,
       obj.roleSelectionCards,
-      votes
+      votes,
+      obj.revolutionStatus
     );
   }
 }

--- a/server/src/domain/entities/Player.ts
+++ b/server/src/domain/entities/Player.ts
@@ -22,6 +22,10 @@ export class Player {
 
   private _isReady: boolean;
 
+  private _hasDoubleJoker?: boolean; // 조커 2장 보유 여부
+
+  private _revolutionChoice?: boolean; // 혁명 선택 여부 (true: 혁명, false: 거부)
+
   /**
    * Private constructor - factory method를 통해서만 생성 가능
    */
@@ -32,7 +36,9 @@ export class Player {
     role: number | null = null,
     rank: number | null = null,
     isPassed: boolean = false,
-    isReady: boolean = false
+    isReady: boolean = false,
+    hasDoubleJoker?: boolean,
+    revolutionChoice?: boolean
   ) {
     this.id = id;
     this.nickname = nickname;
@@ -41,6 +47,8 @@ export class Player {
     this._rank = rank;
     this._isPassed = isPassed;
     this._isReady = isReady;
+    this._hasDoubleJoker = hasDoubleJoker;
+    this._revolutionChoice = revolutionChoice;
   }
 
   /**
@@ -75,6 +83,36 @@ export class Player {
 
   get isReady(): boolean {
     return this._isReady;
+  }
+
+  get hasDoubleJoker(): boolean | undefined {
+    return this._hasDoubleJoker;
+  }
+
+  get revolutionChoice(): boolean | undefined {
+    return this._revolutionChoice;
+  }
+
+  /**
+   * 조커 2장 보유 플래그 설정
+   */
+  markHasDoubleJoker(): void {
+    this._hasDoubleJoker = true;
+  }
+
+  /**
+   * 조커 2장 보유 플래그 제거
+   */
+  clearDoubleJokerFlag(): void {
+    this._hasDoubleJoker = undefined;
+  }
+
+  /**
+   * 혁명 선택
+   * @param wantRevolution true: 혁명 일으킴, false: 혁명 거부
+   */
+  selectRevolution(wantRevolution: boolean): void {
+    this._revolutionChoice = wantRevolution;
   }
 
   /**
@@ -190,6 +228,8 @@ export class Player {
     rank: number | null;
     isPassed: boolean;
     isReady: boolean;
+    hasDoubleJoker?: boolean;
+    revolutionChoice?: boolean;
   } {
     return {
       id: this.id.value, // PlayerId를 string으로 변환
@@ -199,6 +239,8 @@ export class Player {
       rank: this._rank,
       isPassed: this._isPassed,
       isReady: this._isReady,
+      hasDoubleJoker: this._hasDoubleJoker,
+      revolutionChoice: this._revolutionChoice,
     };
   }
 
@@ -213,6 +255,8 @@ export class Player {
     rank?: number | null;
     isPassed?: boolean;
     isReady?: boolean;
+    hasDoubleJoker?: boolean;
+    revolutionChoice?: boolean;
   }): Player {
     const playerId = PlayerId.create(obj.id); // string을 PlayerId로 변환
     const cards = obj.cards
@@ -225,7 +269,9 @@ export class Player {
       obj.role || null,
       obj.rank || null,
       obj.isPassed || false,
-      obj.isReady || false
+      obj.isReady || false,
+      obj.hasDoubleJoker,
+      obj.revolutionChoice
     );
   }
 }

--- a/server/src/domain/entities/Player.ts
+++ b/server/src/domain/entities/Player.ts
@@ -211,6 +211,19 @@ export class Player {
   }
 
   /**
+   * 카드 제거
+   * @param card 제거할 카드
+   * @throws Error 카드를 찾을 수 없는 경우
+   */
+  removeCard(card: Card): void {
+    const index = this._cards.findIndex((c) => c.rank === card.rank && c.isJoker === card.isJoker);
+    if (index === -1) {
+      throw new Error('Card not found in player cards');
+    }
+    this._cards.splice(index, 1);
+  }
+
+  /**
    * 플레이어가 게임을 완료했는지 확인 (카드를 모두 냈는지)
    */
   hasFinished(): boolean {

--- a/server/src/domain/services/TaxService.ts
+++ b/server/src/domain/services/TaxService.ts
@@ -1,0 +1,124 @@
+/**
+ * TaxService.ts
+ *
+ * 세금 교환 도메인 서비스
+ * 게임 진행 중 순위에 따른 세금 교환 로직을 담당
+ *
+ * 세금 교환 규칙:
+ * - 4명: 1위 ↔ 4위 2장씩
+ * - 5명 이상: 1위 ↔ 꼴찌 2장씩, 2위 ↔ 차하위 1장씩
+ *
+ * 세금 카드 선택 규칙:
+ * - 높은 순위(1, 2등): 큰 숫자 카드(rank가 높은 값, 약한 카드)를 줌
+ * - 낮은 순위(꼴찌, 차하위): 작은 숫자 카드(rank가 낮은 값, 강한 카드)를 줌
+ */
+
+import { Card } from '../entities/Card';
+import { Player } from '../entities/Player';
+import { TaxExchange } from '../types/GameTypes';
+
+/**
+ * 세금으로 줄 카드를 자동으로 선택합니다.
+ * @param cards 플레이어의 카드 목록
+ * @param count 선택할 카드 개수
+ * @param selectLargest true: 큰 숫자 카드(약한 카드) 선택, false: 작은 숫자 카드(강한 카드) 선택
+ * @returns 선택된 카드 배열
+ */
+export function selectTaxCardsAutomatically(
+  cards: Card[],
+  count: number,
+  selectLargest: boolean
+): Card[] {
+  // 카드를 복사하여 정렬
+  const sortedCards = cards.slice().sort((a, b) => {
+    // 조커는 rank 13으로 취급 (단독으로 낼 때)
+    const rankA = a.isJoker ? 13 : a.rank;
+    const rankB = b.isJoker ? 13 : b.rank;
+
+    if (selectLargest) {
+      // 큰 숫자 카드 우선 (약한 카드)
+      return rankB - rankA;
+    }
+    // 작은 숫자 카드 우선 (강한 카드)
+    return rankA - rankB;
+  });
+
+  // 상위 count개 선택
+  return sortedCards.slice(0, count);
+}
+
+/**
+ * 게임의 세금 교환을 초기화하고 자동으로 수행합니다.
+ * @param players 게임의 모든 플레이어 (rank 순으로 정렬되어야 함)
+ * @returns 세금 교환 정보 배열
+ */
+export function initializeTaxExchanges(players: Player[]): TaxExchange[] {
+  const playerCount = players.length;
+
+  // rank 순으로 정렬 (1등, 2등, ..., 꼴찌)
+  const sortedPlayers = players.slice().sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+
+  const exchangePairs: Array<{ fromIdx: number; toIdx: number; count: number }> = [];
+
+  if (playerCount === 4) {
+    // 4명: 1위 ↔ 4위 2장씩
+    exchangePairs.push(
+      { fromIdx: 3, toIdx: 0, count: 2 }, // 4위 → 1위
+      { fromIdx: 0, toIdx: 3, count: 2 } // 1위 → 4위
+    );
+  } else if (playerCount >= 5) {
+    // 5명 이상: 1위 ↔ 꼴찌 2장씩, 2위 ↔ 차하위 1장씩
+    exchangePairs.push(
+      { fromIdx: playerCount - 1, toIdx: 0, count: 2 }, // 꼴찌 → 1위
+      { fromIdx: 0, toIdx: playerCount - 1, count: 2 }, // 1위 → 꼴찌
+      { fromIdx: playerCount - 2, toIdx: 1, count: 1 }, // 차하위 → 2위
+      { fromIdx: 1, toIdx: playerCount - 2, count: 1 } // 2위 → 차하위
+    );
+  }
+
+  // Step 1: 각 플레이어가 줄 카드를 미리 결정
+  const cardsToGiveByPlayer = new Map<string, Card[]>();
+  for (const pair of exchangePairs) {
+    const fromPlayer = sortedPlayers[pair.fromIdx];
+    if (!cardsToGiveByPlayer.has(fromPlayer.id.value)) {
+      const cardsToGive = selectTaxCardsAutomatically(
+        fromPlayer.cards,
+        pair.count,
+        pair.fromIdx <= 1 // 높은 순위(1, 2등)는 큰 카드를 줌
+      );
+      cardsToGiveByPlayer.set(fromPlayer.id.value, cardsToGive);
+    }
+  }
+
+  // Step 2: 모든 카드 교환 실행
+  for (const pair of exchangePairs) {
+    const fromPlayer = sortedPlayers[pair.fromIdx];
+    const toPlayer = sortedPlayers[pair.toIdx];
+    const cardsGiven = cardsToGiveByPlayer.get(fromPlayer.id.value) || [];
+
+    // 카드 제거
+    cardsGiven.forEach((card) => {
+      fromPlayer.removeCard(card);
+    });
+
+    // 카드 추가
+    toPlayer.addCards(cardsGiven);
+  }
+
+  // Step 3: UI용 교환 기록 생성
+  const taxExchanges: TaxExchange[] = exchangePairs.map((pair) => {
+    const fromPlayer = sortedPlayers[pair.fromIdx];
+    const toPlayer = sortedPlayers[pair.toIdx];
+
+    const cardsGiven = cardsToGiveByPlayer.get(fromPlayer.id.value) || [];
+
+    return {
+      fromPlayerId: fromPlayer.id.value,
+      toPlayerId: toPlayer.id.value,
+      cardCount: pair.count,
+      cardsGiven: cardsGiven.map((c) => c.toPlainObject()),
+    };
+  });
+
+  return taxExchanges;
+}

--- a/server/src/domain/services/index.ts
+++ b/server/src/domain/services/index.ts
@@ -7,3 +7,4 @@
 export * as TurnService from './TurnService';
 export * as ValidationService from './ValidationService';
 export * as DeckService from './DeckService';
+export * as TaxService from './TaxService';

--- a/server/src/domain/types/GameTypes.ts
+++ b/server/src/domain/types/GameTypes.ts
@@ -26,3 +26,14 @@ export interface RoleSelectionCard {
   isSelected: boolean;
   selectedBy?: string;
 }
+
+/**
+ * 세금 교환 정보
+ * 세금 페이즈에서 사용
+ */
+export interface TaxExchange {
+  fromPlayerId: string;
+  toPlayerId: string;
+  cardCount: number;
+  cardsGiven: ReturnType<Card['toPlainObject']>[];
+}

--- a/server/src/presentation/socket/adapters/CardEventAdapter.ts
+++ b/server/src/presentation/socket/adapters/CardEventAdapter.ts
@@ -84,11 +84,11 @@ export class CardEventAdapter extends BaseEventAdapter {
     socket.on(
       SocketEvent.SELECT_DECK,
       async (
-        { roomId, deckIndex }: { roomId: string; deckIndex: number },
+        { roomId, cardIndex }: { roomId: string; cardIndex: number },
         callback?: SocketCallback
       ) => {
         // Command: 덱 선택
-        const result = await this.commandService.selectDeck(roomId, socket.id, deckIndex);
+        const result = await this.commandService.selectDeck(roomId, socket.id, cardIndex);
 
         await this.handleSocketEvent(result, callback, roomId);
       }

--- a/server/src/presentation/socket/adapters/base/BaseEventAdapter.ts
+++ b/server/src/presentation/socket/adapters/base/BaseEventAdapter.ts
@@ -132,7 +132,8 @@ export abstract class BaseEventAdapter implements ISocketEventPort {
     try {
       const gameState = await this.queryService.getGameState(roomId);
       if (gameState) {
-        this.io.to(roomId).emit('GAME_STATE_UPDATED', { game: gameState });
+        // Legacy 클라이언트 호환성을 위해 gameState를 직접 전송
+        this.io.to(roomId).emit('GAME_STATE_UPDATED', gameState);
       }
     } catch (error) {
       console.error('Failed to emit game state:', error);


### PR DESCRIPTION
## 📋 개요

Phase 5-1: 테스트 작성 작업 완료

**Related**: Issue #35

## ✅ 작성한 테스트

### 1. Domain Layer 테스트
- [x] **TaxService** 도메인 서비스 테스트 (14개)
  - 카드 자동 선택 로직 (큰/작은 숫자 카드 우선)
  - 4/5/6/8명 플레이어 세금 교환 로직
  - 엣지 케이스 및 에러 처리

### 2. Application Layer 테스트
- [x] **SelectRevolutionUseCase** 테스트 (9개)
  - 혁명 승인/거부 시나리오
  - 대혁명 vs 일반혁명
  - 세금 교환 자동 처리
- [x] **StartGameUseCase** 테스트 (11개)
  - 게임 시작 성공/실패 케이스
  - 덱 및 역할 선택 카드 초기화
  - 플레이어 수 검증 (4-8명)

### 3. E2E 테스트
- [x] **전체 게임 플로우 테스트** (2개)
  - 대기실 → 역할 선택 → 덱 선택 → 혁명/세금 → 게임 플레이 준비
  - 대혁명 시나리오 검증

## 🔧 구현한 기능

### 세금 교환 시스템
- TaxService 도메인 서비스 구현
- 플레이어 수에 따른 자동 세금 교환 처리
- SelectRevolutionUseCase에 세금 교환 로직 통합

### 혁명 시스템
- 조커 2장 보유자 확인 로직
- 대혁명/일반혁명 처리
- SelectDeckUseCase에 혁명 체크 추가

## 📊 테스트 결과

```
Test Suites: 35 passed, 35 total
Tests:       1 skipped, 696 passed, 697 total
```

✅ TypeScript 빌드 통과
✅ 작성한 테스트 파일 Lint 통과

## 📝 E2E 테스트 수준

**현재 E2E 테스트**: 게임 준비 단계 통합 검증 (약 70% 커버리지)
- ✅ 대기실 → 역할 선택 → 덱 선택 → 혁명/세금 준비
- ❌ 실제 게임 플레이 (카드 내기, 패스, 턴 순환)
- ❌ Socket.IO 통합 테스트
- ❌ 동시성 처리 테스트

## 🔄 변경 사항

- 4개의 테스트 파일 추가 (TaxService, SelectRevolutionUseCase, StartGameUseCase, FullGameFlow)
- SelectRevolutionUseCase, SelectDeckUseCase에 세금 교환 로직 추가
- Game Entity에 혁명 상태 관리 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)